### PR TITLE
Fix for #28: Scanning XML files and #45: Setting TargetJDK lost

### DIFF
--- a/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -40,7 +40,7 @@ public class PMDConfigurationForm {
 
     private static final Object[] columnNames = new String[] {"Option", "Value"};
     private static final String[] optionNames = new String[] {"Target JDK", "Encoding"};
-    private static final String[] defaultValues = new String[] {"1.4", ""};
+    private static final String[] defaultValues = new String[] {"1.8", ""};
 
     public PMDConfigurationForm() {
         //Get the action group defined

--- a/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -56,6 +56,7 @@ public class PMDConfigurationForm {
         buttonPanel.setLayout(new BorderLayout());
         buttonPanel.add(toolbar.getComponent(), BorderLayout.CENTER);
 
+        table1.putClientProperty("terminateEditOnFocusLost", true); // fixes issue #45
         ruleList.setModel(new MyListModel(new ArrayList<String>()));
         skipTestsCheckBox.addChangeListener(new CheckBoxChangeListener());
     }

--- a/src/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
@@ -16,12 +16,10 @@ import com.intellij.openapi.vfs.VirtualFileFilter;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.plugins.bodhi.pmd.core.PMDResultCollector;
-import com.intellij.plugins.bodhi.pmd.filter.VirtualFileFilters;
 import com.intellij.plugins.bodhi.pmd.tree.PMDRuleNode;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -44,6 +42,7 @@ public class PMDInvoker {
     // The singleton instance
     private static final PMDInvoker instance = new PMDInvoker();
     public static final String JAVA_EXTENSION = "java";
+    private static final String XML_EXTENSION = "xml";
 
     /**
      * Prevents instantiation by other classes.
@@ -105,17 +104,13 @@ public class PMDInvoker {
                 //toolWindow.displayErrorMessage("Please select a file to process first");
                 return;
             }
-            List<VirtualFileFilter> filters = new ArrayList<VirtualFileFilter>();
-            filters.add(fileHasExtension(JAVA_EXTENSION));
-            filters.add(fileInSources(project));
+            VirtualFileFilter filter = or(fileHasExtension(JAVA_EXTENSION), fileHasExtension(XML_EXTENSION));
+            filter = and(filter, fileInSources(project));
             if(projectComponent.isSkipTestSources())
             {
-                filters.add(VirtualFileFilters.not(fileInTestSources(project)));
+                filter = and(filter, not(fileInTestSources(project)));
             }
-            VirtualFileFilter filter = VirtualFileFilters.or(
-                    isDirectory(),
-                    and(filters.toArray(new VirtualFileFilter[filters.size()]))
-            );
+            filter = or(filter, isDirectory());
             for (VirtualFile selectedFile : selectedFiles) {
                 //Add all java files recursively
                 PMDUtil.listFiles(selectedFile, files, filter, true);


### PR DESCRIPTION
Fix for #28: Scanning XML files and #45: Setting TargetJDK lost 
Additionally, set the default JDK to 1.8 in stead of old 1.4. 
Needs pmd-xml-5.8.1.jar or newer bundled in the binary distribution. Also bundled pmd-java and pmd-core need to be of this or newer version. 