### PR TITLE
PR for Fix for amitdev/PMD-IntelliJ #68: PMD 6.4+ typeIs() function not supported in rules, it needs the classpath

### DIFF
--- a/src/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
@@ -169,7 +169,7 @@ public class PMDInvoker {
                     PMDResultCollector collector = new PMDResultCollector(isCustomRuleSet);
 
                     //Get the tree nodes from result collector
-                    List<DefaultMutableTreeNode> results = collector.getResults(files, rules[i], projectComponent.getOptions());
+                    List<DefaultMutableTreeNode> results = collector.getResults(files, rules[i], projectComponent);
 
                     if (results.size() != 0) {
                         if (isCustomRuleSet) {

--- a/src/com/intellij/plugins/bodhi/pmd/PMDUtil.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDUtil.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.OrderEnumerator;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileFilter;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.FileFilter;
 import java.util.List;
+import java.util.StringJoiner;
 
 import static java.util.Arrays.asList;
 
@@ -74,6 +76,15 @@ public class PMDUtil {
 
     public static List<Module> getProjectModules(Project project) {
         return asList(ModuleManager.getInstance(project).getModules());
+    }
+
+    public static String getFullClassPathForAllModules(Project project) {
+        List<Module> modules = getProjectModules(project);
+        StringJoiner joiner = new StringJoiner(File.pathSeparator);
+        for (Module module : modules) {
+            joiner.add(OrderEnumerator.orderEntries(module).recursively().getPathsList().getPathsString());
+        }
+        return joiner.toString();
     }
 
     /**

--- a/src/com/intellij/plugins/bodhi/pmd/handlers/PMDCheckinHandler.java
+++ b/src/com/intellij/plugins/bodhi/pmd/handlers/PMDCheckinHandler.java
@@ -119,7 +119,7 @@ public class PMDCheckinHandler extends CheckinHandler {
         PMDResultCollector collector = new PMDResultCollector(true);
         List<File> files = new ArrayList<>(checkinProjectPanel.getFiles());
 
-        List<DefaultMutableTreeNode> ruleSetResults = collector.getResults(files, ruleSet, plugin.getOptions());
+        List<DefaultMutableTreeNode> ruleSetResults = collector.getResults(files, ruleSet, plugin);
         if (!ruleSetResults.isEmpty()) {
             result = createRuleSetNode(ruleSet, ruleSetResults);
         }


### PR DESCRIPTION
Tested to run the rules as expected now, using the classpath from the intelliJ project.