### PR TITLE
User intellij-FileChooser and add name

### DIFF
--- a/src/com/intellij/plugins/bodhi/pmd/PMDConfigurable.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDConfigurable.java
@@ -11,8 +11,9 @@ import javax.swing.*;
 public class PMDConfigurable implements Configurable {
     private PMDConfigurationForm form;
     private PMDProjectComponent component;
-
+    final Project project;
     public PMDConfigurable(Project project) {
+        this.project=project;
         component = project.getComponent(PMDProjectComponent.class);
     }
 
@@ -28,7 +29,7 @@ public class PMDConfigurable implements Configurable {
 
     public JComponent createComponent() {
         if (form == null) {
-            form = new PMDConfigurationForm();
+            form = new PMDConfigurationForm(project);
         }
         return form.getRootPanel();
     }

--- a/src/com/intellij/plugins/bodhi/pmd/PMDConfigurable.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDConfigurable.java
@@ -11,7 +11,8 @@ import javax.swing.*;
 public class PMDConfigurable implements Configurable {
     private PMDConfigurationForm form;
     private PMDProjectComponent component;
-    final Project project;
+    private final Project project;
+
     public PMDConfigurable(Project project) {
         this.project=project;
         component = project.getComponent(PMDProjectComponent.class);

--- a/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -316,6 +316,7 @@ public class PMDConfigurationForm {
                     final VirtualFile toSelect = project.getBaseDir();
 
                     final FileChooserDescriptor descriptor = new FileChooserDescriptor(true, false, false, false, false, false);
+                    descriptor.withFileFilter(virtualFile -> virtualFile.getName().endsWith(".xml"));
 
                     final VirtualFile chosen = FileChooser.chooseFile(descriptor, BrowsePanel.this, project, toSelect);
                     if (chosen != null) {

--- a/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -41,13 +41,13 @@ public class PMDConfigurationForm {
     private JTable table1;
     private JPanel mainPanel;
     private JCheckBox skipTestsCheckBox;
+
     private boolean isModified;
+    private Project project;
 
     private static final Object[] columnNames = new String[] {"Option", "Value"};
     private static final String[] optionNames = new String[] {"Target JDK", "Encoding"};
     private static final String[] defaultValues = new String[] {"1.8", ""};
-
-    private Project project;
 
     public PMDConfigurationForm(final Project project) {
         this.project = project;

--- a/src/com/intellij/plugins/bodhi/pmd/PMDResultPanel.java
+++ b/src/com/intellij/plugins/bodhi/pmd/PMDResultPanel.java
@@ -469,24 +469,4 @@ public class PMDResultPanel extends JPanel {
         }
     }
 
-    private class ExportAction extends AnAction {
-        private ExportAction() {
-            super("Export", "Export the results to file", IconLoader.getIcon("/actions/export.png"));
-        }
-
-        public void actionPerformed(AnActionEvent e) {
-            DialogBuilder db = new DialogBuilder(PMDUtil.getProjectComponent(e).getCurrentProject());
-            db.addOkAction();
-            db.addCancelAction();
-            db.setTitle("Export to File");
-            final PMDConfigurationForm.BrowsePanel panel = new PMDConfigurationForm.BrowsePanel("", db);
-            db.setOkActionEnabled(true);
-            db.show();
-            //If ok is selected add the selected ruleset
-            if (db.getDialogWrapper().getExitCode() == DialogWrapper.OK_EXIT_CODE) {
-                String fileName = panel.getText();
-                System.out.println("Save to : " + fileName);
-            }
-        }
-    }
 }

--- a/src/com/intellij/plugins/bodhi/pmd/core/PMDResultCollector.java
+++ b/src/com/intellij/plugins/bodhi/pmd/core/PMDResultCollector.java
@@ -160,6 +160,32 @@ public class PMDResultCollector {
         return "Invalid File";
     }
 
+    public static RuleSet loadRuleSet(String path) throws InvalidRuleSetException {
+        Thread.currentThread().setContextClassLoader(PMDResultCollector.class.getClassLoader());
+        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        try {
+            RuleSet rs = ruleSetFactory.createRuleSet(path);
+            if (rs.getRules().size() != 0) {
+                return rs;
+            }
+        } catch (RuntimeException | RuleSetNotFoundException e) {
+            throw  new InvalidRuleSetException(e);
+        }
+        throw  new InvalidRuleSetException("Invalid File");
+    }
+
+    public static class InvalidRuleSetException extends Exception {
+
+        public InvalidRuleSetException(final String message) {
+            super(message);
+        }
+
+        public InvalidRuleSetException(final Throwable cause) {
+            super(cause);
+        }
+
+    }
+
     private class PMDResultRenderer extends AbstractIncrementingRenderer {
 
         private final List<DefaultMutableTreeNode> pmdResults;


### PR DESCRIPTION
This pull requests adds usage of the intellij-filechooser, which has better usability (e.g. project-root as default instead of filesystem-root), and shows the ruleset-name in the "Run PMD"-context-menu-action.

Maybe both changes are interesting for you?