### PR TITLE
fix: externel annotation processor rulesets

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
@@ -18,10 +18,14 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.plugins.bodhi.pmd.core.PMDProgressRenderer;
 import com.intellij.plugins.bodhi.pmd.core.PMDResultCollector;
-import com.intellij.plugins.bodhi.pmd.tree.*;
+import com.intellij.plugins.bodhi.pmd.tree.PMDRootNode;
+import com.intellij.plugins.bodhi.pmd.tree.PMDRuleSetEntryNode;
+import com.intellij.plugins.bodhi.pmd.tree.PMDRuleSetNode;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -68,8 +72,8 @@ public class PMDInvoker {
     /**
      * Runs PMD based on the given parameters, and populates result.
      *
-     * @param actionEvent The action event that triggered run
-     * @param ruleSetPaths The ruleSetPath(s) for rules to run
+     * @param actionEvent     The action event that triggered run
+     * @param ruleSetPaths    The ruleSetPath(s) for rules to run
      * @param isCustomRuleSet Is it a custom ruleset or not.
      */
     public void runPMD(AnActionEvent actionEvent, String ruleSetPaths, boolean isCustomRuleSet) {
@@ -138,10 +142,11 @@ public class PMDInvoker {
 
     /**
      * Runs PMD on given files.
-     *  @param project the project
-     * @param ruleSetPaths The ruleSetPath(s) of rules to run
-     * @param files The files on which to run
-     * @param isCustomRuleSet Is it a custom ruleset or not.
+     *
+     * @param project          the project
+     * @param ruleSetPaths     The ruleSetPath(s) of rules to run
+     * @param files            The files on which to run
+     * @param isCustomRuleSet  Is it a custom ruleset or not.
      * @param projectComponent
      */
     public void processFiles(Project project, final String ruleSetPaths, final List<File> files, final boolean isCustomRuleSet, final PMDProjectComponent projectComponent) {
@@ -169,32 +174,30 @@ public class PMDInvoker {
                 rootNode.setRuleSetCount(ruleSetPathArray.length);
                 rootNode.setRunning(true);
                 PMDProgressRenderer progressRenderer = new PMDProgressRenderer(progress, files.size() * ruleSetPathArray.length);
-                for (String ruleSetPath : ruleSetPathArray) {
-                    progress.setText("Running : " + ruleSetPath + " on " + files.size() + " file(s)");
+                progress.setText("Running : " + ruleSetPathArray.length + " PMD rules on " + files.size() + " file(s)");
 
-                    //Create a result collector to get results
-                    PMDResultCollector collector = new PMDResultCollector();
+                //Create a result collector to get results
+                PMDResultCollector collector = new PMDResultCollector();
 
-                    //Get the tree nodes from result collector
-                    List<PMDRuleSetEntryNode> resultRuleNodes = collector.runPMDAndGetResults(files, ruleSetPath, projectComponent, progressRenderer);
-                    // sort rules by priority, rule and suppressed nodes are comparable
-                    resultRuleNodes.sort(null);
+                //Get the tree nodes from result collector
+                List<PMDRuleSetEntryNode> resultRuleNodes = collector.runPMDAndGetResults(files, Arrays.asList(ruleSetPathArray), projectComponent, progressRenderer);
+                // sort rules by priority, rule and suppressed nodes are comparable
+                resultRuleNodes.sort(null);
 
-                    if (!resultRuleNodes.isEmpty()) {
-                        String ruleSetName = PMDUtil.getBareFileNameFromPath(ruleSetPath);
-                        String  desc = PMDResultCollector.getRuleSetDescription(ruleSetPath);
-                        PMDRuleSetNode ruleSetNode = resultPanel.addCreateRuleSetNodeAtRoot(ruleSetName);
-                        ruleSetNode.setToolTip(desc);
-                        //Add all rule nodes to the tree
-                        for (PMDRuleSetEntryNode resultRuleNode : resultRuleNodes) {
-                            resultPanel.addNode(ruleSetNode, resultRuleNode);
-                        }
-                        rootNode.calculateCounts();
-                        resultPanel.reloadResultTree();
+                if (!resultRuleNodes.isEmpty()) {
+                    String ruleSetName = PMDUtil.getBareFileNameFromPath(ruleSetPaths);
+                    String desc = PMDResultCollector.getRuleSetDescription(ruleSetPaths);
+                    PMDRuleSetNode ruleSetNode = resultPanel.addCreateRuleSetNodeAtRoot(ruleSetName);
+                    ruleSetNode.setToolTip(desc);
+                    //Add all rule nodes to the tree
+                    for (PMDRuleSetEntryNode resultRuleNode : resultRuleNodes) {
+                        resultPanel.addNode(ruleSetNode, resultRuleNode);
                     }
-                    if (progress.isCanceled()) {
-                        break;
-                    }
+                    rootNode.calculateCounts();
+                    resultPanel.reloadResultTree();
+                }
+                if (progress.isCanceled()) {
+                    // TODO what happens here ? Implement a PMD.onStop callback ?
                 }
                 resultPanel.addProcessingErrorsNodeToRootIfHasAny(); // as last node
                 rootNode.calculateCounts();

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDExternalAnnotator.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDExternalAnnotator.java
@@ -1,5 +1,6 @@
 package com.intellij.plugins.bodhi.pmd.annotator;
 
+import com.ibm.icu.impl.coll.Collation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.ExternalAnnotator;
 import com.intellij.lang.annotation.HighlightSeverity;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Display PMD violations in the editor and in the problem view
@@ -27,15 +29,16 @@ public class PMDExternalAnnotator extends ExternalAnnotator<FileInfo, PMDAnnotat
     @Override
     public @Nullable PMDAnnotations doAnnotate(FileInfo info) {
         PMDProjectComponent projectComponent = info.getProject().getComponent(PMDProjectComponent.class);
-        if (projectComponent.getInEditorAnnotationRuleSets().isEmpty()) {
+
+        Set<String> ruleSets = projectComponent.getInEditorAnnotationRuleSets();
+
+        if (ruleSets.isEmpty()) {
             return null;
         }
 
         PMDResultCollector collector = new PMDResultCollector();
         PMDAnnotationRenderer renderer = new PMDAnnotationRenderer();
-        for (String ruleSetPath : projectComponent.getInEditorAnnotationRuleSets()) {
-            collector.runPMDAndGetResults(List.of(info.getFile()), ruleSetPath, projectComponent, renderer);
-        }
+        collector.runPMDAndGetResults(List.of(info.getFile()), List.copyOf(ruleSets), projectComponent, renderer);
 
         return renderer.getResult(info.getDocument());
     }
@@ -48,10 +51,10 @@ public class PMDExternalAnnotator extends ExternalAnnotator<FileInfo, PMDAnnotat
 
         Document document = annotationResult.getDocument();
         for (RuleViolation violation : annotationResult.getReport().getViolations()) {
-            int startLineOffset = document.getLineStartOffset(violation.getBeginLine()-1);
+            int startLineOffset = document.getLineStartOffset(violation.getBeginLine() - 1);
             int endOffset = violation.getEndLine() - violation.getBeginLine() > 5 // Only mark first line for long violations
-                    ? document.getLineEndOffset(violation.getBeginLine()-1)
-                    : document.getLineStartOffset(violation.getEndLine()-1) + violation.getEndColumn();
+                    ? document.getLineEndOffset(violation.getBeginLine() - 1)
+                    : document.getLineStartOffset(violation.getEndLine() - 1) + violation.getEndColumn();
 
             holder.newAnnotation(getSeverity(violation), "PMD: " + violation.getDescription())
                     .tooltip("PMD: " + violation.getRule().getName() +

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDResultAsTreeRenderer.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDResultAsTreeRenderer.java
@@ -29,11 +29,11 @@ public class PMDResultAsTreeRenderer extends AbstractIncrementingRenderer {
     private final UselessSuppressionsHelper uselessSupHelper;
     private final Map<RuleKey, PMDRuleNode> ruleKeyToNodeMap = new TreeMap<>(); // order by priority and then name
 
-    public PMDResultAsTreeRenderer(List<PMDRuleSetEntryNode> pmdRuleSetResults, PMDErrorBranchNode errorsNode, String ruleSetPath) {
+    public PMDResultAsTreeRenderer(List<PMDRuleSetEntryNode> pmdRuleSetResults, PMDErrorBranchNode errorsNode, List<String> ruleSetPaths) {
         super("pmdplugin", "PMD plugin renderer");
         this.pmdRuleResultNodes = pmdRuleSetResults;
         processingErrorsNode = errorsNode;
-        uselessSupHelper = new UselessSuppressionsHelper(ruleSetPath);
+        uselessSupHelper = new UselessSuppressionsHelper(ruleSetPaths);
     }
 
     @Override

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/core/UselessSuppressionsHelper.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/core/UselessSuppressionsHelper.java
@@ -41,7 +41,7 @@ public class UselessSuppressionsHelper {
     final Map<String, Set<String>> classMethodToRuleNameOfSuppressedViolationsMap = new HashMap<>();
     final Map<String, Set<String>> classMethodToRuleNameOfViolationsMap = new HashMap<>();
     static final RuleKey USING_SUPPRESS_KEY = new RuleKey("UsingSuppressWarnings", 5);
-    private final String ruleSetPath;
+    private final List<String> ruleSetPaths;
 
     /**
      * the rule names of the rule set, lazily initialized, only when needed
@@ -49,8 +49,8 @@ public class UselessSuppressionsHelper {
     private Set<String> ruleNames;
     private volatile ViolatingAnnotationHolder annotationContextResult;
 
-    UselessSuppressionsHelper(String ruleSetPath) {
-        this.ruleSetPath = ruleSetPath;
+    UselessSuppressionsHelper(List<String> ruleSetPaths) {
+        this.ruleSetPaths = ruleSetPaths;
     }
 
     void storeRuleNameForMethod(Report.SuppressedViolation suppressed) {
@@ -150,7 +150,11 @@ public class UselessSuppressionsHelper {
     boolean ruleSetContains(String ruleName) {
         if (ruleNames == null) {
             try {
-                Collection<Rule> rules = PMDResultCollector.getRuleSet(ruleSetPath).getRules();
+                Collection<Rule> rules = new ArrayList<>();
+                for (String ruleSetPath : ruleSetPaths) {
+                    rules.addAll(PMDResultCollector.getRuleSet(ruleSetPath).getRules());
+                }
+
                 ruleNames = new HashSet<>(rules.size(), 1);
                 for (Rule rule : rules) {
                     ruleNames.add(rule.getName());

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/handlers/PMDCheckinHandler.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/handlers/PMDCheckinHandler.java
@@ -101,30 +101,30 @@ public class PMDCheckinHandler extends CheckinHandler {
         PMDResultCollector.clearReport();
 
         List<PMDRuleSetNode> ruleSetResultNodes = new ArrayList<>();
-        for (String ruleSetPath : plugin.getCustomRuleSetPaths()) {
-            PMDRuleSetNode ruleSetResultNode = scanFiles(ruleSetPath, plugin);
-            if (ruleSetResultNode != null) {
-                ruleSetResultNodes.add(ruleSetResultNode);
-            }
+        PMDRuleSetNode ruleSetResultNode = scanFiles(plugin.getCustomRuleSetPaths(), plugin);
+        if (ruleSetResultNode != null) {
+            ruleSetResultNodes.add(ruleSetResultNode);
         }
         return processScanResults(ruleSetResultNodes, project);
     }
 
-    private PMDRuleSetNode scanFiles(String ruleSetPath, PMDProjectComponent plugin) {
+    private PMDRuleSetNode scanFiles(List<String> ruleSetPaths, PMDProjectComponent plugin) {
         PMDRuleSetNode ruleSetResultNode = null;
         PMDResultCollector collector = new PMDResultCollector();
         List<File> files = new ArrayList<>(checkinProjectPanel.getFiles());
 
-        List<PMDRuleSetEntryNode> ruleSetResultNodes = collector.runPMDAndGetResults(files, ruleSetPath, plugin);
+        List<PMDRuleSetEntryNode> ruleSetResultNodes = collector.runPMDAndGetResults(files, ruleSetPaths, plugin);
         if (!ruleSetResultNodes.isEmpty()) {
-            ruleSetResultNode = createRuleSetNodeWithResults(ruleSetPath, ruleSetResultNodes);
+            ruleSetResultNode = createRuleSetNodeWithResults(ruleSetPaths, ruleSetResultNodes);
         }
         return ruleSetResultNode;
     }
 
-    private PMDRuleSetNode createRuleSetNodeWithResults(String ruleSetPath, List<PMDRuleSetEntryNode> ruleResultNodes) {
-        ruleSetPath = PMDUtil.getFileNameFromPath(ruleSetPath) + ";" + ruleSetPath;
-        PMDRuleSetNode ruleSetNode = PMDTreeNodeFactory.getInstance().createRuleSetNode(ruleSetPath);
+    private PMDRuleSetNode createRuleSetNodeWithResults(List<String> ruleSetPaths, List<PMDRuleSetEntryNode> ruleResultNodes) {
+        String ruleSetFiles = ruleSetPaths.stream()
+                .reduce("", (String previous, String current) -> PMDUtil.getFileNameFromPath(current) + ";" + previous);
+
+        PMDRuleSetNode ruleSetNode = PMDTreeNodeFactory.getInstance().createRuleSetNode(ruleSetFiles);
 
         for (PMDRuleSetEntryNode ruleResultNode : ruleResultNodes) {
             ruleSetNode.add(ruleResultNode);


### PR DESCRIPTION
This PR improves upon the recently proposed #152 

Instead of iterating over the list of PMD Ruleset Locations we now group them together and execute the PMD check only once. The net.sourceforge.pmd.PMDConfiguration class from already allows a list of Ruleset locations.

This also fixes (as a side effect) an issue with the new external annotation processor where checks would no longer work if you select a custom ruleset with a pre-defined