### PR TITLE
Store configuration in a separate `PMDPlugin.xml` file

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
@@ -34,10 +34,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 
 @State(
-  name = "PDMPlugin",
+  name = "PMDPlugin",
   storages = {
     @Storage(
-      value = "$PROJECT_FILE$"
+      value = "PMDPlugin.xml"
     )}
 )
 public class PMDProjectComponent implements ProjectComponent, PersistentStateComponent<PersistentData>, Disposable {


### PR DESCRIPTION
Closes https://github.com/amitdev/PMD-Intellij/issues/100.

Following the implementation of:

- `google-java-format` plugin: https://github.com/google/google-java-format/blob/v1.23.0/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java#L27-L29

- `checkstyle-idea` plugin: https://github.com/jshiell/checkstyle-idea/blob/5.95.0/src/main/java/org/infernus/idea/checkstyle/config/ProjectConfigurationState.java#L24

Our configuration file will be stored as `PMDPlugin.xml` in the `.idea` folder.

![image](https://github.com/user-attachments/assets/296d0591-d831-4d51-8eea-f9ba7a27588b)

/cc @amitdev 