### PR TITLE
Declare ActionGroups "Pre Defined" and "Custom Rules" as groups

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
@@ -118,10 +118,11 @@ public class PMDProjectComponent implements ProjectComponent, PersistentStateCom
      * Now for > 1 projects open, merge the rule sets of shared actions (menu) and current project
      */
     void updateCustomRulesMenu() {
-            PMDCustom actionGroup = (PMDCustom) ActionManager.getInstance().getAction("PMDCustom");
+        ActionManager actionManager = ActionManager.getInstance();
+        PMDCustom actionGroup = (PMDCustom) actionManager.getAction("PMDCustom");
             if (numProjectsOpen.get() != 1) {
                 // merge actions from menu and from settings to not lose any when switching between projects
-                AnAction[] currentActions = actionGroup.getChildren((ActionManager)null);
+                AnAction[] currentActions = actionGroup.getChildren(null, actionManager);
                 Set<String> ruleSetPathsFromMenu = new LinkedHashSet<>();
                 for (AnAction action : currentActions) {
                     if (action.getSynonyms().size() == 1) {

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedMenuGroup.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedMenuGroup.java
@@ -19,13 +19,10 @@ import java.util.Properties;
  * @author bodhi
  * @version 1.0
  */
-public class PreDefinedMenuGroup extends ActionGroup {
+public class PreDefinedMenuGroup extends DefaultActionGroup {
 
     // A string that represents all the rulesets as comma separated value.
     private static String allRules = "";
-
-    //All the children of this group
-    private DefaultActionGroup children = new DefaultActionGroup("Pre Defined", true);
 
     private PMDProjectComponent component;
 
@@ -50,9 +47,7 @@ public class PreDefinedMenuGroup extends ActionGroup {
             String[] rulesetFilenames = props.getProperty(RULESETS_FILENAMES_KEY).split(PMDInvoker.RULE_DELIMITER);
 
             //We have 'All' rules in addition to the rulesets
-            //First one is 'All'
-            children.removeAll();
-            children.add(action);
+            add(action);
 
             for (int i=0; i < rulesetFilenames.length; ++i) {
                 final String ruleFileName = rulesetFilenames[i];
@@ -65,7 +60,7 @@ public class PreDefinedMenuGroup extends ActionGroup {
                         getComponent().setLastRunActionAndRules(e, ruleFileName, false);
                     }
                 };
-                children.add(ruleAction);
+                add(ruleAction);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -78,10 +73,6 @@ public class PreDefinedMenuGroup extends ActionGroup {
             return Thread.currentThread().getContextClassLoader().getResourceAsStream(RULESETS_PROPERTY_FILE);
         }
         return resourceAsStream;
-    }
-
-    public AnAction[] getChildren(@Nullable AnActionEvent event) {
-        return new AnAction[]{this.children};
     }
 
     public void setComponent(PMDProjectComponent component) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,9 +22,9 @@
       <add-to-group group-id="ChangesViewPopupMenu" anchor="last"/>
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
 
-      <action class="com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup" id="PMDPredefined"
+      <group id="PMDPredefined" class="com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup"
               popup="true" text="Pre Defined"/>
-      <action id="PMDCustom" class="com.intellij.plugins.bodhi.pmd.actions.PMDCustom"
+      <group id="PMDCustom" class="com.intellij.plugins.bodhi.pmd.actions.PMDCustom"
               popup="true" text="Custom Rules"/>
     </group>
 


### PR DESCRIPTION
This fixes the following two exceptions "ActionGroup should be registered using &lt;group&gt; tag":

<details>

```
com.intellij.diagnostic.PluginException: ActionGroup should be registered using <group> tag: id="PMDPredefined" class="com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup" [Plugin: PMDPlugin]
	at com.intellij.openapi.actionSystem.ActionStub.initAction(ActionStub.java:108)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.convertStub(ActionManagerImpl.kt:1714)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.getAction(ActionManagerImpl.kt:2198)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.access$getAction(ActionManagerImpl.kt:1)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.getAction(ActionManagerImpl.kt:411)
	at com.intellij.plugins.bodhi.pmd.PMDProjectComponent.registerActions(PMDProjectComponent.java:89)
	at com.intellij.plugins.bodhi.pmd.PMDProjectComponent.initComponent(PMDProjectComponent.java:81)

com.intellij.diagnostic.PluginException: ActionGroup should be registered using <group> tag: id="PMDCustom" class="com.intellij.plugins.bodhi.pmd.actions.PMDCustom" [Plugin: PMDPlugin]
	at com.intellij.openapi.actionSystem.ActionStub.initAction(ActionStub.java:108)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.convertStub(ActionManagerImpl.kt:1714)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.getAction(ActionManagerImpl.kt:2198)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImplKt.access$getAction(ActionManagerImpl.kt:1)
	at com.intellij.openapi.actionSystem.impl.ActionManagerImpl.getAction(ActionManagerImpl.kt:411)
	at com.intellij.plugins.bodhi.pmd.PMDProjectComponent.updateCustomRulesMenu(PMDProjectComponent.java:121)
	at com.intellij.plugins.bodhi.pmd.PMDProjectComponent.initComponent(PMDProjectComponent.java:80)
```

</details>

They seem to become relevant at least with 2024.3 - which doesn't load the plugin anymore because of this.

This PR obsoletes #181 and #188 , as it contains the same fix - but allows the plugin to still run on 2024.1 (which is pluginSince ...)


Fixes #185 