### PR TITLE
Display supported Java Language Version in settings

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/ConfigOption.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/ConfigOption.java
@@ -1,10 +1,12 @@
 package com.intellij.plugins.bodhi.pmd;
 
+import net.sourceforge.pmd.lang.LanguageRegistry;
+
 /**
  * Configuration options enumeration. Separation between key for persistent state and description to show in the UI.
  */
 public enum ConfigOption {
-    TARGET_JDK("Target JDK", "Target JDK (max: 20-preview)", "20-preview"),
+    TARGET_JDK("Target JDK", "Target JDK (max: " + latestSupportJavaVersionByPmd() + ")", latestSupportJavaVersionByPmd()),
     STATISTICS_URL("Statistics URL", "Statistics URL to export usage anonymously", ""),
     THREADS("Threads", "Threads (fastest: " + PMDUtil.AVAILABLE_PROCESSORS + ")", String.valueOf(PMDUtil.AVAILABLE_PROCESSORS));
 
@@ -22,6 +24,10 @@ public enum ConfigOption {
      * defaultValue is used in the UI if no value is provided yet by the user
      */
     private final String defaultValue;
+
+    private static String latestSupportJavaVersionByPmd() {
+        return LanguageRegistry.PMD.getLanguageById("java").getLatestVersion().toString();
+    }
 
     public static ConfigOption fromKey(String key) {
         for (ConfigOption option : ConfigOption.values()) {

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/ConfigOption.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/ConfigOption.java
@@ -26,7 +26,7 @@ public enum ConfigOption {
     private final String defaultValue;
 
     private static String latestSupportJavaVersionByPmd() {
-        return LanguageRegistry.PMD.getLanguageById("java").getLatestVersion().toString();
+        return LanguageRegistry.PMD.getLanguageById("java").getLatestVersion().getVersion();
     }
 
     public static ConfigOption fromKey(String key) {

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDExternalAnnotator.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDExternalAnnotator.java
@@ -38,7 +38,7 @@ public class PMDExternalAnnotator extends ExternalAnnotator<FileInfo, PMDAnnotat
     public FileInfo collectInformation(@NotNull PsiFile file, @NotNull Editor editor, boolean hasErrors) {
         PMDProjectComponent projectComponent = file.getProject().getComponent(PMDProjectComponent.class);
         String type = projectComponent.getOptionToValue().get(ConfigOption.TARGET_JDK);
-        LanguageVersion version = LanguageRegistry.CPD.getLanguageVersionById("java", type);
+        LanguageVersion version = LanguageRegistry.PMD.getLanguageVersionById("java", type);
 
         return new FileInfo(file, editor.getDocument(), version);
     }


### PR DESCRIPTION
Currently the settings dialog suggests to use the latest supported java version and displays this is "20-preview" - but that is not supported anymore by the used PMD version.

This PR changes that to determine the actual correct version from PMD.