### PR TITLE
Allow installation on IntelliJ 2024.3.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,14 +8,14 @@ pluginVersion = 2.0.2
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 241
-pluginUntilBuild = 242.*
+pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2024.2
+pluginVerifierIdeVersions = IC-2024.1.7, IC-2024.2.4, IC-2024.3
 
 platformType = IC
-platformVersion = 2024.2
+platformVersion = 2024.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
@@ -118,10 +118,11 @@ public class PMDProjectComponent implements ProjectComponent, PersistentStateCom
      * Now for > 1 projects open, merge the rule sets of shared actions (menu) and current project
      */
     void updateCustomRulesMenu() {
-            PMDCustom actionGroup = (PMDCustom) ActionManager.getInstance().getAction("PMDCustom");
+        ActionManager actionManager = ActionManager.getInstance();
+        PMDCustom actionGroup = (PMDCustom) actionManager.getAction("PMDCustom");
             if (numProjectsOpen.get() != 1) {
                 // merge actions from menu and from settings to not lose any when switching between projects
-                AnAction[] currentActions = actionGroup.getChildren((ActionManager)null);
+                AnAction[] currentActions = actionGroup.getChildren(null, actionManager);
                 Set<String> ruleSetPathsFromMenu = new LinkedHashSet<>();
                 for (AnAction action : currentActions) {
                     if (action.getSynonyms().size() == 1) {


### PR DESCRIPTION
Note: pluginSinceBuild is still 241. This changes
the platformVersion back to 241, so that it is built against this version to guarantee backwards-compatibility. The incompatibility in PMDProjectComponent is also fixed (refs #181, #185, #188).

See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#multipleIDEVersions

Note: This PR requires most likely #190 so that the plugin works in 2024.3.

Fixes #187 