### PR TITLE
Move settings into tools category

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,7 +33,7 @@
 
   </actions>
   <extensions defaultExtensionNs="com.intellij">
-    <projectConfigurable id="PMD" displayName="PMD" instance="com.intellij.plugins.bodhi.pmd.PMDConfigurable"/>
+    <projectConfigurable id="PMD" parentId="tools" displayName="PMD" instance="com.intellij.plugins.bodhi.pmd.PMDConfigurable"/>
     <checkinHandlerFactory id="PMDCheckinHandlerFactory"
                            implementation="com.intellij.plugins.bodhi.pmd.handlers.PMDCheckinHandlerFactory"/>
 


### PR DESCRIPTION
I noticed that PMD settings were in `Other Settings` and the other static analyzer plugins like qodana are in the `Tools` category. So I propose to move them into `Tools` for consistency.