### PR TITLE
CHANGELOG.md - Remove 2.0.3-snapshot and keep Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 # PMDPlugin Changelog
 
 ## [Unreleased]
-## [2.0.3-snapshot]
 ### Added
 - Update to PMD version 7.7.0
 - Support for IntelliJ 2024.3


### PR DESCRIPTION
@jborgers I think, the version in CHANGELOG.md must stay `[Unreleased]` - this is what is then displayed in the "What's new section". This is done automatically during the [release job](https://github.com/amitdev/PMD-Intellij/blob/master/.github/workflows/release.yml) by the gradle task "publishPlugin", which executes [patchChangelog](https://github.com/amitdev/PMD-Intellij/blob/d133b354e7c668f4bd215333f9dc4403c2bd5c4f/build.gradle.kts#L93). This sets the version (replacing unreleased). If we add a version prior to the release, then the "What's new" section is probably empty.
