### PR TITLE
Enable Kotlin rules

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginName = PMD
 pluginRepositoryUrl = https://github.com/amitdev/PMD-Intellij
 # SemVer format -> https://semver.org
-pluginVersion = 2.0.4
+pluginVersion = 2.0.5-SNAPSHOT
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/ConfigOption.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/ConfigOption.java
@@ -8,7 +8,8 @@ import java.util.Objects;
  * Configuration options enumeration. Separation between key for persistent state and description to show in the UI.
  */
 public enum ConfigOption {
-    TARGET_JDK("Target JDK", "Target JDK (max: " + latestSupportJavaVersionByPmd() + ")", latestSupportJavaVersionByPmd()),
+    TARGET_JDK("Target JDK", "Target JDK (max: " + latestSupportLanguageVersionByPmd("java") + ")", latestSupportLanguageVersionByPmd("java")),
+    TARGET_KOTLIN_VERSION("Target Kotlin version", "Target Kotlin version (max: " + latestSupportLanguageVersionByPmd("kotlin") + ")", latestSupportLanguageVersionByPmd("kotlin")),
     STATISTICS_URL("Statistics URL", "Statistics URL to export usage anonymously", ""),
     THREADS("Threads", "Threads (fastest: " + PMDUtil.AVAILABLE_PROCESSORS + ")", String.valueOf(PMDUtil.AVAILABLE_PROCESSORS));
 
@@ -27,8 +28,8 @@ public enum ConfigOption {
      */
     private final String defaultValue;
 
-    private static String latestSupportJavaVersionByPmd() {
-        return Objects.requireNonNull(LanguageRegistry.PMD.getLanguageById("java")).getLatestVersion().getVersion();
+    private static String latestSupportLanguageVersionByPmd(String langId) {
+        return Objects.requireNonNull(LanguageRegistry.PMD.getLanguageById(langId)).getLatestVersion().getVersion();
     }
 
     public static ConfigOption fromKey(String key) {

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -33,8 +33,10 @@ import java.io.IOException;
 import java.util.*;
 import java.util.List;
 
-import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup.RULESETS_FILENAMES_KEY;
-import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup.RULESETS_PROPERTY_JAVA_FILE;
+import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedAbstractClass.RULESETS_FILENAMES_KEY;
+import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedJavaMenuGroup.RULESETS_JAVA_PROPERTY_FILE;
+import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedKotlinMenuGroup.RULESETS_KOTLIN_PROPERTY_FILE;
+
 
 /**
  * This class represents the UI for settings.
@@ -117,7 +119,7 @@ public class PMDConfigurationForm {
 
         Properties props = new Properties();
         try {
-            props.load(getClass().getClassLoader().getResourceAsStream(RULESETS_PROPERTY_JAVA_FILE));
+            props.load(getClass().getClassLoader().getResourceAsStream(RULESETS_JAVA_PROPERTY_FILE));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -77,6 +77,7 @@ public class PMDConfigurationForm {
         buttonPanel.add(toolbar.getComponent(), BorderLayout.CENTER);
 
         optionsTable.putClientProperty("terminateEditOnFocusLost", true); // fixes issue #45
+        optionsTable.setRowHeight(optionsTable.getRowHeight() + 5); // increase space around text
         ruleSetPathJList.setModel(new RuleSetListModel(new ArrayList<>()));
         inEditorAnnotationRuleSets.setModel(new RuleSetListModel(new ArrayList<>()));
         inEditorAnnotationRuleSets.getSelectionModel().addListSelectionListener(new SelectionChangeListener());
@@ -338,7 +339,8 @@ public class PMDConfigurationForm {
                 for (LanguageVersion langVersion : langVersions) {
                     versions.add(langVersion.getVersion());
                 }
-                String tipText = "For " + langId + " version take one of: " + String.join(",", versions.subList(5, versions.size()));
+                String maxTenMostRecentVersions = String.join(",", versions.subList(Math.max(versions.size() - 10, 0), versions.size()));
+                String tipText = "For " + langId + " version take one of: " + maxTenMostRecentVersions;
                 optionsTable.setToolTipText(tipText);
                 isModified = origIsMod;
             }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -34,7 +34,7 @@ import java.util.*;
 import java.util.List;
 
 import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup.RULESETS_FILENAMES_KEY;
-import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup.RULESETS_PROPERTY_FILE;
+import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup.RULESETS_PROPERTY_JAVA_FILE;
 
 /**
  * This class represents the UI for settings.
@@ -117,7 +117,7 @@ public class PMDConfigurationForm {
 
         Properties props = new Properties();
         try {
-            props.load(getClass().getClassLoader().getResourceAsStream(RULESETS_PROPERTY_FILE));
+            props.load(getClass().getClassLoader().getResourceAsStream(RULESETS_PROPERTY_JAVA_FILE));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -29,11 +29,9 @@ import javax.swing.table.TableModel;
 import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.List;
 
-import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedAbstractClass.RULESETS_FILENAMES_KEY;
 import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedJavaMenuGroup.RULESETS_JAVA_PROPERTY_FILE;
 import static com.intellij.plugins.bodhi.pmd.actions.PreDefinedKotlinMenuGroup.RULESETS_KOTLIN_PROPERTY_FILE;
 
@@ -117,13 +115,11 @@ public class PMDConfigurationForm {
         }
         skipTestsCheckBox.setSelected(dataProjComp.isSkipTestSources());
 
-        Properties props = new Properties();
-        try {
-            props.load(getClass().getClassLoader().getResourceAsStream(RULESETS_JAVA_PROPERTY_FILE));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        List<String> allRules = new ArrayList<>(List.of(props.getProperty(RULESETS_FILENAMES_KEY).split(PMDInvoker.RULE_DELIMITER)));
+        List<String> javaRules = PMDUtil.loadRules(RULESETS_JAVA_PROPERTY_FILE);
+        List<String> kotlinRules = PMDUtil.loadRules(RULESETS_KOTLIN_PROPERTY_FILE);
+
+        List<String> allRules = new ArrayList<>(javaRules);
+        allRules.addAll(kotlinRules);
         allRules.addAll(customRuleSetPaths);
 
         RuleSetListModel inEditorAnnotationModel = new RuleSetListModel(allRules);
@@ -311,35 +307,38 @@ public class PMDConfigurationForm {
             isModified = isModified || orig == null || !orig.equals(aValue);
             switch (row) {
                 // row 0: Target JDK
-                case 0: validateJavaVersion((String) aValue, row, column, orig, origIsMod);
+                case 0: validateLanguageVersion((String) aValue, row, column, orig, origIsMod, "java");
                 break;
-                // row 1: statistics URL
-                case 1: validateStatUrl((String) aValue, row, column, orig, origIsMod);
+                // row 1: Target Kotlin Version
+                case 1: validateLanguageVersion((String) aValue, row, column, orig, origIsMod, "kotlin");
                 break;
-                // row 2: threads
-                case 2: validateThreads((String) aValue, row, column, orig, origIsMod);
+                // row 2: statistics URL
+                case 2: validateStatUrl((String) aValue, row, column, orig, origIsMod);
+                break;
+                // row 3: threads
+                case 3: validateThreads((String) aValue, row, column, orig, origIsMod);
                 break;
             }
         }
 
-        private void validateJavaVersion(String versionInput, int row, int column, Object orig, boolean origIsMod) {
+        private void validateLanguageVersion(String versionInput, int row, int column, Object orig, boolean origIsMod, String langId) {
             if (versionInput.equals(orig)) {
                 return;
             }
-            Language java = Objects.requireNonNull(LanguageRegistry.PMD.getLanguageById("java"));
-            boolean isRegistered = java.hasVersion(versionInput);
+            Language language = Objects.requireNonNull(LanguageRegistry.PMD.getLanguageById(langId));
+            boolean isRegistered = language.hasVersion(versionInput);
             if (isRegistered) {
-                String registeredVersion = Objects.requireNonNull(java.getVersion(versionInput)).getVersion();
-                optionsTable.setToolTipText("Java version " + registeredVersion);
+                String registeredVersion = Objects.requireNonNull(language.getVersion(versionInput)).getVersion();
+                optionsTable.setToolTipText(langId + " version " + registeredVersion);
             }
             else {
                 super.setValueAt(orig, row, column);
-                List<LanguageVersion> langVersions = java.getVersions();
+                List<LanguageVersion> langVersions = language.getVersions();
                 List<String> versions = new ArrayList<>();
                 for (LanguageVersion langVersion : langVersions) {
                     versions.add(langVersion.getVersion());
                 }
-                String tipText = "For JDK take one of: " + String.join(",", versions.subList(5, versions.size()));
+                String tipText = "For " + langId + " version take one of: " + String.join(",", versions.subList(5, versions.size()));
                 optionsTable.setToolTipText(tipText);
                 isModified = origIsMod;
             }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
@@ -51,6 +51,7 @@ public class PMDInvoker {
     private static final PMDInvoker instance = new PMDInvoker();
     private static final VirtualFileFilter SUPPORTED_EXTENSIONS = or(
             fileHasExtension("java"),
+            fileHasExtension("kt"),
             fileHasExtension("xml"),
             fileHasExtension("cls"),
             fileHasExtension("trigger"),

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
@@ -10,7 +10,8 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.plugins.bodhi.pmd.actions.PMDCustom;
-import com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup;
+import com.intellij.plugins.bodhi.pmd.actions.PreDefinedJavaMenuGroup;
+import com.intellij.plugins.bodhi.pmd.actions.PreDefinedKotlinMenuGroup;
 import com.intellij.plugins.bodhi.pmd.core.PMDResultCollector;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -70,9 +71,15 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
     public void initComponent() {
         //Add custom rules as menu items if defined.
         updateCustomRulesMenu();
-        ActionGroup actionGroup = registerActions("PMDPredefined");
-        if (actionGroup != null)
-            ((PreDefinedMenuGroup) actionGroup).setComponent(this);
+
+        ActionGroup actionGroupJava = registerActions("PMDPredefinedJava");
+        if (actionGroupJava != null)
+            ((PreDefinedJavaMenuGroup) actionGroupJava).setComponent(this);
+
+        ActionGroup actionGroupKotlin = registerActions("PMDPredefinedKotlin");
+        if (actionGroupKotlin != null)
+            ((PreDefinedKotlinMenuGroup) actionGroupKotlin).setComponent(this);
+
         registerActions("PMDCustom");
     }
 

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
@@ -69,8 +69,6 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
     }
 
     public void initComponent() {
-        //Add custom rules as menu items if defined.
-        updateCustomRulesMenu();
 
         ActionGroup actionGroupJava = registerActions("PMDPredefinedJava");
         if (actionGroupJava != null)
@@ -297,8 +295,9 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
      */
     public void loadState(PersistentData state) {
         customRuleSetPaths.clear();
-        optionToValue.clear();
         customRuleSetPaths.addAll(state.getCustomRuleSets());
+
+        optionToValue.clear();
         for (String key : state.getOptionKeyToValue().keySet()) {
             if (key.equals("Encoding")) { // replace unused 'Encoding' by 'Statistics URL'
                 optionToValue.put(ConfigOption.STATISTICS_URL, "");
@@ -313,6 +312,9 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
 
         this.skipTestSources = state.isSkipTestSources();
         this.scanFilesBeforeCheckin = state.isScanFilesBeforeCheckin();
+
+        // Add custom rules as menu items if defined.
+        updateCustomRulesMenu();
     }
 
     public void skipTestSources(boolean skipTestSources)
@@ -332,7 +334,4 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
     public boolean isScanFilesBeforeCheckin() {
         return scanFilesBeforeCheckin;
     }
-
-
-
 }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
@@ -237,6 +237,22 @@ public class PMDUtil {
         return fileBase;
     }
 
+    /**
+     * The category name is the first part of the path, before the first '/'.
+     * For example: "category/java/...": the category name is "java"
+     * @param ruleFileName the path of the rule set
+     * @return the category name
+     */
+    public static String getCategoryNameFromPath(String ruleFileName) {
+        int firstSlashIndex = ruleFileName.indexOf('/');
+        if (firstSlashIndex <= 0 || firstSlashIndex == ruleFileName.length() - 1) {
+            return "";
+        }
+        String[] parts = ruleFileName.split("/");
+        return parts.length > 1 ? parts[1] : "";
+    }
+
+
     private static boolean isMatchingExtension(File pathname, String extension) {
         return pathname.isDirectory() || pathname.getName().endsWith("." + extension);
     }
@@ -270,4 +286,5 @@ public class PMDUtil {
         }
         return isValid;
     }
+
 }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
@@ -38,8 +38,11 @@ public class PMDUtil {
 
     public static final Pattern HOST_NAME_PATTERN = Pattern.compile(".+\\.([a-z]+\\.[a-z]+)/.+");
     public static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();
-    private static final String JPINPOINT_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/java/jpinpoint-rules.xml";
-    private static final Map<String, String> KNOWN_CUSTOM_RULES = Map.of("jpinpoint-rules", JPINPOINT_RULES);
+    private static final String JPINPOINT_JAVA_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/java/jpinpoint-rules.xml";
+    private static final String JPINPOINT_KOTLIN_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/kotlin/jpinpoint-kotlin-rules.xml";
+    private static final Map<String, String> KNOWN_CUSTOM_RULES = Map.of(
+            "jpinpoint-java-rules", JPINPOINT_JAVA_RULES,
+            "jpinpoint-kotlin-rules", JPINPOINT_KOTLIN_RULES);
     private static volatile Map<String, String> validCustomRules; // lazy initialized
 
     /**

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
@@ -16,12 +16,10 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -38,6 +36,7 @@ public class PMDUtil {
 
     public static final Pattern HOST_NAME_PATTERN = Pattern.compile(".+\\.([a-z]+\\.[a-z]+)/.+");
     public static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();
+    public static final String RULESETS_FILENAMES_KEY = "rulesets.filenames";
     private static final String JPINPOINT_JAVA_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/java/jpinpoint-java-rules.xml";
     private static final String JPINPOINT_KOTLIN_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/kotlin/jpinpoint-kotlin-rules.xml";
     private static final Map<String, String> KNOWN_CUSTOM_RULES = Map.of(
@@ -285,6 +284,16 @@ public class PMDUtil {
             isValid = false;
         }
         return isValid;
+    }
+
+    public static @NotNull List<String> loadRules(String rulesetsPropertyFile) {
+        Properties props = new Properties();
+        try {
+            props.load(PMDUtil.class.getClassLoader().getResourceAsStream(rulesetsPropertyFile));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load rule set property file: " + rulesetsPropertyFile, e);
+        }
+        return new ArrayList<>(List.of(props.getProperty(RULESETS_FILENAMES_KEY).split(PMDInvoker.RULE_DELIMITER)));
     }
 
 }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
@@ -38,7 +38,7 @@ public class PMDUtil {
 
     public static final Pattern HOST_NAME_PATTERN = Pattern.compile(".+\\.([a-z]+\\.[a-z]+)/.+");
     public static final int AVAILABLE_PROCESSORS = Runtime.getRuntime().availableProcessors();
-    private static final String JPINPOINT_JAVA_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/java/jpinpoint-rules.xml";
+    private static final String JPINPOINT_JAVA_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/java/jpinpoint-java-rules.xml";
     private static final String JPINPOINT_KOTLIN_RULES = "https://raw.githubusercontent.com/jborgers/PMD-jPinpoint-rules/pmd7/rulesets/kotlin/jpinpoint-kotlin-rules.xml";
     private static final Map<String, String> KNOWN_CUSTOM_RULES = Map.of(
             "jpinpoint-java-rules", JPINPOINT_JAVA_RULES,

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PMDCustom.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PMDCustom.java
@@ -7,7 +7,7 @@ import org.jetbrains.annotations.NotNull;
 public class PMDCustom extends DefaultActionGroup {
 
     public PMDCustom() {
-        super("Custom Rules", true);
+        super("Custom", true);
     }
 
     @Override

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedAbstractClass.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedAbstractClass.java
@@ -24,18 +24,12 @@ public abstract class PreDefinedAbstractClass extends DefaultActionGroup {
 
     private PMDProjectComponent component;
 
-    public static final String RULESETS_FILENAMES_KEY = "rulesets.filenames";
-
     /**
      * Loads all the predefined rulesets in PMD and create actions for them.
      */
     PreDefinedAbstractClass(String rulesetFilename) {
-        Properties props = new Properties();
         try {
-            // Load the property file which has all the rulesets for Java and Kotlin.
-            props.load(getRuleResourceStream(rulesetFilename));
-
-            List<String> rulesetFilenames = List.of(props.getProperty(RULESETS_FILENAMES_KEY).split(PMDInvoker.RULE_DELIMITER));
+            List<String> rulesetFilenames = PMDUtil.loadRules(rulesetFilename);
 
             for (final String ruleFileName : rulesetFilenames) {
                 final String ruleName = PMDUtil.getBareFileNameFromPath(ruleFileName);
@@ -62,7 +56,7 @@ public abstract class PreDefinedAbstractClass extends DefaultActionGroup {
                 }
             }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to add pre defined rules for '" + rulesetFilename + "' to action group", e);
         }
     }
 

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedJavaMenuGroup.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedJavaMenuGroup.java
@@ -1,0 +1,12 @@
+package com.intellij.plugins.bodhi.pmd.actions;
+
+public class PreDefinedJavaMenuGroup extends PreDefinedAbstractClass {
+
+    // The ruleset property file which lists all the predefined rulesets
+    public static final String RULESETS_JAVA_PROPERTY_FILE = "category/java/categories.properties";
+
+    public PreDefinedJavaMenuGroup() {
+        super(RULESETS_JAVA_PROPERTY_FILE);
+    }
+
+}

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedKotlinMenuGroup.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedKotlinMenuGroup.java
@@ -1,0 +1,12 @@
+package com.intellij.plugins.bodhi.pmd.actions;
+
+public class PreDefinedKotlinMenuGroup extends PreDefinedAbstractClass {
+
+    // The ruleset property file which lists all the predefined rulesets
+    public static final String RULESETS_KOTLIN_PROPERTY_FILE = "category/kotlin/categories.properties";
+
+    public PreDefinedKotlinMenuGroup() {
+        super(RULESETS_KOTLIN_PROPERTY_FILE);
+    }
+
+}

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedMenuGroup.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/actions/PreDefinedMenuGroup.java
@@ -2,6 +2,7 @@ package com.intellij.plugins.bodhi.pmd.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Constraints;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.plugins.bodhi.pmd.PMDInvoker;
 import com.intellij.plugins.bodhi.pmd.PMDProjectComponent;
@@ -10,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.InputStream;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * This ActionGroup defines the actions for pre defined rulesets that
@@ -21,63 +22,81 @@ import java.util.Properties;
  */
 public class PreDefinedMenuGroup extends DefaultActionGroup {
 
-    // A string that represents all the rulesets as comma separated value.
-    private static String allRules = "";
-
     private PMDProjectComponent component;
 
     //The ruleset property file which lists all the predefined rulesets
-    public static final String RULESETS_PROPERTY_FILE = "category/java/categories.properties";
+    public static final String RULESETS_PROPERTY_JAVA_FILE = "category/java/categories.properties";
+    public static final String RULESETS_PROPERTY_KOTLIN_FILE = "category/kotlin/categories.properties";
     public static final String RULESETS_FILENAMES_KEY = "rulesets.filenames";
 
     /**
      * Loads all the predefined rulesets in PMD and create actions for them.
      */
     public PreDefinedMenuGroup() {
-        AnAction action = new AnAction("All") {
-            public void actionPerformed(@NotNull AnActionEvent e) {
-                PMDInvoker.getInstance().runPMD(e, allRules);
-                getComponent().setLastRunActionAndRules(e, allRules, false);
-            }
-        };
-        Properties props = new Properties();
+        Properties propsJava = new Properties();
+        Properties propsKotlin = new Properties();
         try {
-            //Load the property file which has all the rulesets.
-            props.load(getRuleResourceStream());
-            String[] rulesetFilenames = props.getProperty(RULESETS_FILENAMES_KEY).split(PMDInvoker.RULE_DELIMITER);
+            // Load the property file which has all the rulesets for Java and Kotlin.
+            propsJava.load(getRuleResourceStream(RULESETS_PROPERTY_JAVA_FILE));
+            propsKotlin.load(getRuleResourceStream(RULESETS_PROPERTY_KOTLIN_FILE));
 
-            //We have 'All' rules in addition to the rulesets
-            add(action);
+            List<String> javaRules = List.of(propsJava.getProperty(RULESETS_FILENAMES_KEY).split(PMDInvoker.RULE_DELIMITER));
+            List<String> kotlinRules = List.of(propsKotlin.getProperty(RULESETS_FILENAMES_KEY).split(PMDInvoker.RULE_DELIMITER));
+            
+            Map<String, List<String>> categoryToRulesMap = new HashMap<>();
+            categoryToRulesMap.put("java", javaRules);
+            categoryToRulesMap.put("kotlin", kotlinRules);
 
-            StringBuilder allRulesBuilder = new StringBuilder();
+            List<String> rulesetFilenames = new ArrayList<>();
+            rulesetFilenames.addAll(javaRules);
+            rulesetFilenames.addAll(kotlinRules);
 
-            for (int i = 0; i < rulesetFilenames.length; ++i) {
-                final String ruleFileName = rulesetFilenames[i];
+            // Group rules by category for menu usage
+            Map<String, DefaultActionGroup> categoryGroups = new HashMap<>();
+
+            for (final String ruleFileName : rulesetFilenames) {
                 final String ruleName = PMDUtil.getBareFileNameFromPath(ruleFileName);
+                final String categoryName = PMDUtil.getCategoryNameFromPath(ruleFileName);
 
-                allRulesBuilder.append(ruleFileName);
-                if (i < rulesetFilenames.length - 1) {
-                    allRulesBuilder.append(PMDInvoker.RULE_DELIMITER);
-                }
+                // Create category group if not already created
+                categoryGroups.computeIfAbsent(categoryName, k -> {
+                    DefaultActionGroup categoryGroup = new DefaultActionGroup(categoryName, true);
+                    add(categoryGroup);
+                    return categoryGroup;
+                });
 
+                DefaultActionGroup categoryGroup = categoryGroups.get(categoryName);
+
+                // Add rule action to the respective category group
                 AnAction ruleAction = new AnAction(ruleName) {
                     public void actionPerformed(@NotNull AnActionEvent e) {
                         PMDInvoker.getInstance().runPMD(e, ruleFileName);
                         getComponent().setLastRunActionAndRules(e, ruleFileName, false);
                     }
                 };
-                add(ruleAction);
+                categoryGroup.add(ruleAction);
+
+                // Ensure an "All" action for the category group if not already added
+                if (categoryGroup.getChildrenCount() == 1) { // First action being added to the group
+                    AnAction allAction = new AnAction("All") {
+                        public void actionPerformed(@NotNull AnActionEvent e) {
+                            String categoryAllRules = String.join(PMDInvoker.RULE_DELIMITER, categoryToRulesMap.get(categoryName));
+                            PMDInvoker.getInstance().runPMD(e, categoryAllRules);
+                            getComponent().setLastRunActionAndRules(e, categoryAllRules, false);
+                        }
+                    };
+                    categoryGroup.add(allAction, Constraints.FIRST);
+                }
             }
-            allRules = allRulesBuilder.toString();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    private @Nullable InputStream getRuleResourceStream() {
-        InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(RULESETS_PROPERTY_FILE);
+    private @Nullable InputStream getRuleResourceStream(String filePath) {
+        InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(filePath);
         if (resourceAsStream == null) {
-            return Thread.currentThread().getContextClassLoader().getResourceAsStream(RULESETS_PROPERTY_FILE);
+            return Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath);
         }
         return resourceAsStream;
     }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDAnnotationRenderer.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDAnnotationRenderer.java
@@ -45,6 +45,9 @@ class PMDAnnotationRenderer extends AbstractRenderer {
     }
 
     public PMDAnnotations getResult(Document document) {
+        if (report == null) {
+            throw new IllegalStateException("Report is null. Did you call renderFileReports?");
+        }
         return new PMDAnnotations(report, document);
     }
 }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDResultCollector.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDResultCollector.java
@@ -138,9 +138,19 @@ public class PMDResultCollector {
     @NotNull
     private PMDConfiguration getPmdConfig(String ruleSets, Map<ConfigOption, String> options, Project project) throws IOException {
         PMDConfiguration pmdConfig = new PMDConfiguration();
-        String configVersion = options.get(ConfigOption.TARGET_JDK);
+
+        String configVersion;
+        String language;
+        if (ruleSets != null && ruleSets.contains("kotlin")) {
+            language = "kotlin";
+            configVersion = options.get(ConfigOption.TARGET_KOTLIN_VERSION);
+        } else {
+            language = "java";
+            configVersion = options.get(ConfigOption.TARGET_JDK);
+        }
+
         if (configVersion != null) {
-            LanguageVersion version = LanguageRegistry.PMD.getLanguageVersionById("java", configVersion);
+            LanguageVersion version = LanguageRegistry.PMD.getLanguageVersionById(language, configVersion);
             if (version != null)
                 pmdConfig.setDefaultLanguageVersion(version);
         }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDViolation.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDViolation.java
@@ -1,6 +1,7 @@
 package com.intellij.plugins.bodhi.pmd.core;
 
 
+import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.rule.Rule;
 import net.sourceforge.pmd.lang.rule.RulePriority;
 import net.sourceforge.pmd.reporting.RuleViolation;
@@ -31,10 +32,16 @@ public class PMDViolation implements HasPositionInFile, HasRule, HasMessage {
     public PMDViolation(RuleViolation violation) {
         this.ruleViolation = violation;
         this.positionText = "(" + violation.getBeginLine() + ", " + violation.getBeginColumn() + ") ";
+        // seems the file can be unknown in some cases (for kotlin?)
+        boolean unknownFile = violation.getFileId() == FileId.UNKNOWN;
         String fileName = violation.getFileId().getFileName();
         String className = violation.getAdditionalInfo().get(CLASS_NAME);
         if (className == null || className.isEmpty()) {
-            className = fileName.substring(0, fileName.indexOf('.'));
+            if (unknownFile) {
+                className = "(unknown)";
+            } else {
+                className = fileName.substring(0, fileName.lastIndexOf('.'));
+            }
         }
         String methodName = violation.getAdditionalInfo().get(METHOD_NAME);
         if (methodName == null) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,7 +22,7 @@
              popup="true" text="Pre Defined - Kotlin"/>
 
       <group id="PMDCustom" class="com.intellij.plugins.bodhi.pmd.actions.PMDCustom"
-              popup="true" text="Custom Rules"/>
+              popup="true" text="Custom"/>
     </group>
 
     <!-- The group representing toolbar items in settings -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -40,5 +40,9 @@
     <externalAnnotator
             language="JAVA"
             implementationClass="com.intellij.plugins.bodhi.pmd.annotator.PMDExternalAnnotator"/>
+    <!-- same implementation for both Java and Kotlin: split into specific classes when necessary -->
+    <externalAnnotator
+            language="kotlin"
+            implementationClass="com.intellij.plugins.bodhi.pmd.annotator.PMDExternalAnnotator"/>
   </extensions>
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,8 +16,11 @@
       <add-to-group group-id="ChangesViewPopupMenu" anchor="last"/>
       <add-to-group group-id="EditorPopupMenu" anchor="last"/>
 
-      <group id="PMDPredefined" class="com.intellij.plugins.bodhi.pmd.actions.PreDefinedMenuGroup"
-              popup="true" text="Pre Defined"/>
+      <group id="PMDPredefinedJava" class="com.intellij.plugins.bodhi.pmd.actions.PreDefinedJavaMenuGroup"
+             popup="true" text="Pre Defined - Java"/>
+      <group id="PMDPredefinedKotlin" class="com.intellij.plugins.bodhi.pmd.actions.PreDefinedKotlinMenuGroup"
+             popup="true" text="Pre Defined - Kotlin"/>
+
       <group id="PMDCustom" class="com.intellij.plugins.bodhi.pmd.actions.PMDCustom"
               popup="true" text="Custom Rules"/>
     </group>


### PR DESCRIPTION
Used PMD 7 to enable Kotlin rules. This closes #103.

Added `kt` extension to be included in parsing. Should `kts` and/or `ktm` also be included?

Added an additional "Pre Defined - Kotlin" menu item, next to "Pre Defined - Java". Also considered an extra sub-menu, but wanted to save an extra step. Renamed menu item "Custom Rules" to "Custom" to be in line with the other menu items without "Rules". Let me know what you think.

The Kotlin menu contains the two Kotlin categories available in PMD. This part is dynamic if more categories become available.

Added jPinpoint Kotlin custom rules to the dropdown in the custom rules options panel. Renamed the JPinpoint Java custom rules to contain "java" in the name. 

Enabled Editor annotation processing: Kotlin rule sets are selectable in the option panel, and enabled highlighting in Kotlin editors. The `PMDExternalAnnotator` deals with both Kotlin and Java now, can be split later if necessary. 

Added new option to select Kotlin version, default is 1.8 (currently highest available in PMD 7).

Fixed issue were Persistent State (from `PMDPlugin.xml`) was not processed before the display of the menu. This left the `Custom` rules item disabled after IDE restarts.

