### PR TITLE
Improve display of processing errors in result panel

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDResultPanel.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDResultPanel.java
@@ -323,10 +323,17 @@ public class PMDResultPanel extends JPanel {
         StringBuilder htmlBuilder = new StringBuilder("<html>");
         // style for hyperlink
         htmlBuilder.append("<head><style>a { color: #589df6; text-decoration: none; } a:hover { text-decoration: underline; }</style></head>");
-        // header
-        htmlBuilder.append("<body><b>").append(message.trim().replaceAll(" +", " ")).append("</b>"); // remove redundant spaces
-
-        if (rule != null) {
+        if (rule == null) {
+            // header
+            String[] splits = message.split("\n\n", 2);
+            htmlBuilder.append("<body><b>").append(splits[0]).append("</b>");
+            if (splits.length > 1) {
+                htmlBuilder.append("<br><br>");
+                htmlBuilder.append("<pre>").append(splits[1]).append("</pre>");
+            }
+        } else {
+            // header
+            htmlBuilder.append("<body><b>").append(message.trim().replaceAll(" +", " ")).append("</b>"); // remove redundant spaces
             PropertyDescriptor<?> tagsDescriptor = rule.getPropertyDescriptor("tags");
             if (tagsDescriptor != null) {
                 Object value = rule.getProperty(tagsDescriptor);

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/tree/PMDErrorNode.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/tree/PMDErrorNode.java
@@ -4,6 +4,8 @@ import com.intellij.plugins.bodhi.pmd.core.HasMessage;
 import com.intellij.plugins.bodhi.pmd.core.PMDProcessingError;
 import static com.intellij.ui.SimpleTextAttributes.GRAYED_ATTRIBUTES;
 
+import java.nio.file.Path;
+
 /**
  * PMD leaf tree node for processing errors. It is Navigatable,
  * so that the user can navigate to the source of the processing error.
@@ -20,7 +22,7 @@ public class PMDErrorNode extends PMDLeafNode implements HasMessage {
 
     @Override
     public String getToolTip() {
-        return pmdProcessingError.getCauseMsg();
+        return pmdProcessingError.getMsg();
     }
 
     @Override
@@ -33,7 +35,8 @@ public class PMDErrorNode extends PMDLeafNode implements HasMessage {
         cellRenderer.setIcon(Severity.BLOCKER.getIcon());
         // Show error position greyed, like idea shows.
         cellRenderer.append(pmdProcessingError.getPositionText(), GRAYED_ATTRIBUTES);
-        cellRenderer.append(pmdProcessingError.getMsg()); // includes simple class and file name
+        cellRenderer.append(Path.of(pmdProcessingError.getFilePath()).getFileName().toString());
+        cellRenderer.append(" " + pmdProcessingError.getError().getClass().getSimpleName(), GRAYED_ATTRIBUTES);
     }
 
     @Override


### PR DESCRIPTION
It was hard to see the full details. The full details were only available when exporting the result.

Now the correct line number/column is displayed - you can also navigate to it.
The error message from PMD is displayed in full as the header.

Additionally the full stacktrace is displayed.

Before:
![grafik](https://github.com/user-attachments/assets/e27d7551-a0a1-4516-9236-b0abce3b8921)


After:
![grafik](https://github.com/user-attachments/assets/7c590f0f-ec80-4edc-a5f5-0ad209bf9b10)
