### PR TITLE
Use correct file encoding when analyzing files

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
@@ -91,7 +91,7 @@ public class PMDInvoker {
         PMDResultPanel resultPanel = projectComponent.getResultPanel();
         PMDRootNode rootNode = resultPanel.getRootNode();
 
-        List<File> files = new LinkedList<>();
+        List<VirtualFile> files = new LinkedList<>();
         if (actionEvent.getPlace().equals(ActionPlaces.PROJECT_VIEW_POPUP)
                 || actionEvent.getPlace().equals(ActionPlaces.SCOPE_VIEW_POPUP)
                 || actionEvent.getPlace().equals(ActionPlaces.CHANGES_VIEW_POPUP)
@@ -130,7 +130,7 @@ public class PMDInvoker {
                 rootNode.setFileCount(0);
                 return;
             }
-            files.add(new File(selectedFiles[0].getPresentableUrl()));
+            files.add(selectedFiles[0]);
         }
 
         //Got the files, start processing now
@@ -144,7 +144,7 @@ public class PMDInvoker {
      * @param files The files on which to run
      * @param projectComponent
      */
-    public void processFiles(Project project, final String ruleSetPaths, final List<File> files, final PMDProjectComponent projectComponent) {
+    public void processFiles(Project project, final String ruleSetPaths, final List<VirtualFile> files, final PMDProjectComponent projectComponent) {
         ToolWindow toolWindow = ToolWindowManager.getInstance(project).getToolWindow(PMDProjectComponent.TOOL_ID);
         if (toolWindow != null) {
             toolWindow.activate(null);

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDUtil.java
@@ -92,7 +92,7 @@ public class PMDUtil {
         }
     }
 
-    public static void listFiles(VirtualFile item, final List<File> result, final VirtualFileFilter filter, final boolean skipDirectories) {
+    public static void listFiles(VirtualFile item, final List<VirtualFile> result, final VirtualFileFilter filter, final boolean skipDirectories) {
         VfsUtilCore.visitChildrenRecursively(item, new VirtualFileVisitor<>() {
             @Override
             public boolean visitFile(@NotNull VirtualFile file) {
@@ -100,7 +100,7 @@ public class PMDUtil {
                     return false;
                 }
                 if(!file.isDirectory() || !skipDirectories) {
-                    result.add(new File(file.getPresentableUrl()));
+                    result.add(file);
                 }
                 return true;
             }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDResultCollector.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/core/PMDResultCollector.java
@@ -1,6 +1,7 @@
 package com.intellij.plugins.bodhi.pmd.core;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.plugins.bodhi.pmd.ConfigOption;
 import com.intellij.plugins.bodhi.pmd.PMDProjectComponent;
 import com.intellij.plugins.bodhi.pmd.PMDUtil;
@@ -58,7 +59,7 @@ public class PMDResultCollector {
      * @param ruleSetPath      The path of the ruleSet to run
      * @return list of results
      */
-    public List<PMDRuleSetEntryNode> runPMDAndGetResults(List<File> files, String ruleSetPath, PMDProjectComponent comp) {
+    public List<PMDRuleSetEntryNode> runPMDAndGetResults(List<VirtualFile> files, String ruleSetPath, PMDProjectComponent comp) {
         return this.runPMDAndGetResults(files, ruleSetPath, comp, null);
     }
 
@@ -69,8 +70,8 @@ public class PMDResultCollector {
      * @param ruleSetPath The path of the ruleSet to run
      * @return list of results
      */
-    public List<PMDRuleSetEntryNode> runPMDAndGetResults(List<File> files, String ruleSetPath, PMDProjectComponent comp, Renderer extraRenderer) {
-        return runPMDAndGetResults(files,List.of(), ruleSetPath, comp, extraRenderer);
+    public List<PMDRuleSetEntryNode> runPMDAndGetResults(List<VirtualFile> files, String ruleSetPath, PMDProjectComponent comp, Renderer extraRenderer) {
+        return runPMDAndGetResults(files, List.of(), ruleSetPath, comp, extraRenderer);
     }
 
     /**
@@ -80,7 +81,7 @@ public class PMDResultCollector {
      * @param ruleSetPath The path of the ruleSet to run
      * @return list of results
      */
-    public List<PMDRuleSetEntryNode> runPMDAndGetResults(List<File> files, List<TextFile> textFiles, String ruleSetPath, PMDProjectComponent comp, Renderer extraRenderer) {
+    public List<PMDRuleSetEntryNode> runPMDAndGetResults(List<VirtualFile> files, List<TextFile> textFiles, String ruleSetPath, PMDProjectComponent comp, Renderer extraRenderer) {
         Map<ConfigOption, String> options = comp.getOptionToValue();
         Project project = comp.getCurrentProject();
 
@@ -103,7 +104,10 @@ public class PMDResultCollector {
             if (extraRenderer != null) renderers.add(extraRenderer);
 
             try (PmdAnalysis pmd = PmdAnalysis.create(pmdConfig)) {
-                files.forEach(file -> pmd.files().addFile(file.toPath()));
+                files.forEach(file -> {
+                    pmd.files().setCharset(file.getCharset());
+                    pmd.files().addFile(file.toNioPath());
+                });
                 textFiles.forEach(pmd.files()::addFile);
                 pmd.addRenderers(renderers);
                 report = pmd.performAnalysisAndCollectReport();

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/handlers/PMDCheckinHandler.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/handlers/PMDCheckinHandler.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.vcs.CheckinProjectPanel;
 import com.intellij.openapi.vcs.changes.CommitExecutor;
 import com.intellij.openapi.vcs.checkin.CheckinHandler;
 import com.intellij.openapi.vcs.ui.RefreshableOnComponent;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.plugins.bodhi.pmd.PMDInvoker;
@@ -107,7 +108,7 @@ public class PMDCheckinHandler extends CheckinHandler {
     private PMDRuleSetNode scanFiles(String ruleSetPath, PMDProjectComponent plugin) {
         PMDRuleSetNode ruleSetResultNode = null;
         PMDResultCollector collector = new PMDResultCollector();
-        List<File> files = new ArrayList<>(checkinProjectPanel.getFiles());
+        List<VirtualFile> files = new ArrayList<>(checkinProjectPanel.getVirtualFiles());
 
         List<PMDRuleSetEntryNode> ruleSetResultNodes = collector.runPMDAndGetResults(files, ruleSetPath, plugin);
         if (!ruleSetResultNodes.isEmpty()) {


### PR DESCRIPTION
- Use IntelliJ's VirtualFile until PMD is called
- Set charset before adding file to PMD

If the charset is not explicitly set, then the platform default charset will be used.
This problem might appear e.g. under Windows, where the default charset is in Germany still Cp1252. But the Java source files might be encoded in UTF-8.

