### PR TITLE
Compatibility with IntelliJ 252 (DefaultActionGroup#getChildren)

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
@@ -85,7 +85,7 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
         ActionManager actionMgr = ActionManager.getInstance();
         DefaultActionGroup actionGroup = (DefaultActionGroup) actionMgr.getAction(actionName);
         if (actionGroup != null) {
-            for (AnAction act : actionGroup.getChildren(null, actionMgr)) {
+            for (AnAction act : actionGroup.getChildActionsOrStubs()) {
                 String actName = "PMD" + act.getTemplatePresentation().getText();
                 if (actionMgr.getAction(actName) == null)
                     actionMgr.registerAction(actName, act);
@@ -119,7 +119,7 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
         PMDCustom actionGroup = (PMDCustom) actionManager.getAction("PMDCustom");
             if (numProjectsOpen.get() != 1) {
                 // merge actions from menu and from settings to not lose any when switching between projects
-                AnAction[] currentActions = actionGroup.getChildren(null, actionManager);
+                AnAction[] currentActions = actionGroup.getChildActionsOrStubs();
                 Set<String> ruleSetPathsFromMenu = new LinkedHashSet<>();
                 for (AnAction action : currentActions) {
                     if (action.getSynonyms().size() == 1) {


### PR DESCRIPTION
The method `DefaultActionGroup#getChildren` has been deprecated with 242 (https://github.com/JetBrains/intellij-community/commit/76e9f2f46d8b72fb9c4002366111a766243fe360).  
And has been removed with 252 (https://github.com/JetBrains/intellij-community/commit/e183967c93ef4d34c5409ccc30280179b5a112f6).

This should fix the build problems like

```
Plugin PMDPlugin:2.0.6 against IC-252.13776.59: 2 compatibility problems
Compatibility problems (2): 
    #Invocation of unresolved method com.intellij.plugins.bodhi.pmd.actions.PMDCustom.getChildren(AnActionEvent, ActionManager) : AnAction[]
        Method com.intellij.plugins.bodhi.pmd.PMDProjectComponent.updateCustomRulesMenu() : void contains an *invokevirtual* instruction referencing an unresolved method com.intellij.plugins.bodhi.pmd.actions.PMDCustom.getChildren(com.intellij.openapi.actionSystem.AnActionEvent, com.intellij.openapi.actionSystem.ActionManager) : com.intellij.openapi.actionSystem.AnAction[]. This can lead to **NoSuchMethodError** exception at runtime.
        The method might have been declared in the super classes or in the super interfaces:
          com.intellij.openapi.actionSystem.ActionGroup
          com.intellij.openapi.actionSystem.AnAction
          com.intellij.openapi.actionSystem.DefaultActionGroup
          com.intellij.openapi.actionSystem.ActionUpdateThreadAware
          com.intellij.openapi.project.PossiblyDumbAware
    #Invocation of unresolved method com.intellij.openapi.actionSystem.DefaultActionGroup.getChildren(AnActionEvent, ActionManager) : AnAction[]
        Method com.intellij.plugins.bodhi.pmd.PMDProjectComponent.registerActions(java.lang.String actionName) : com.intellij.openapi.actionSystem.ActionGroup contains an *invokevirtual* instruction referencing an unresolved method com.intellij.openapi.actionSystem.DefaultActionGroup.getChildren(com.intellij.openapi.actionSystem.AnActionEvent, com.intellij.openapi.actionSystem.ActionManager) : com.intellij.openapi.actionSystem.AnAction[]. This can lead to **NoSuchMethodError** exception at runtime.
        The method might have been declared in the super classes or in the super interfaces:
          com.intellij.openapi.actionSystem.ActionGroup
          com.intellij.openapi.actionSystem.AnAction
          com.intellij.openapi.actionSystem.ActionUpdateThreadAware
          com.intellij.openapi.project.PossiblyDumbAware
```

