### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
     outputs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}
-      pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
 
       # Check out the current repository
@@ -64,7 +63,6 @@ jobs:
           CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
           
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
@@ -154,17 +152,19 @@ jobs:
       # Setup Gradle
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-
-      # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v4
         with:
-          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+          # We don't store the cache of the verify job, as it takes too much space.
+          # It contains each IntelliJ IDEA version we test against. These versions
+          # are stored in ~/.gradle/caches/*/transforms/*/*/ideaIC* and each takes about 3GB.
+          # Use "du -hs ~/.gradle/caches/*/transforms/*/*/ideaIC*" to verify.
+          # This would be part of the cache "gradle-transforms-v1-...".
+          # Also, the cache "gradle-dependencies-v1-..." is much bigger for verify job.
+          # In total, the new caches are bigger than 10GB, which are available on GitHub by default.
+          cache-read-only: true
 
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,6 +106,8 @@ intellijPlatform {
 
     pluginVerification {
         ides {
+            // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html#intellijPlatform-pluginVerification-ides
+            // recommended() automatically tests based on the current platformVersion
             recommended()
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,13 +12,6 @@ pluginSinceBuild = 233
 # no upper bound for the version range -> see https://github.com/amitdev/PMD-Intellij/issues/213
 pluginUntilBuild =
 
-# Plugin Verifier integration -> https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-tasks.html#verifyPlugin
-# See https://jb.gg/intellij-platform-builds-list for available build versions.
-# Supporting five last major versions covers about 95% of the users
-# see https://intellij-support.jetbrains.com/hc/en-us/community/posts/18697727524754/comments/18765441074962
-# see https://plugins.jetbrains.com/docs/marketplace/product-versions-in-use-statistics.html
-pluginVerifierIdeVersions = IC-2023.3, IC-2024.1, IC-2024.2, IC-2024.3, IC-2025.1
-
 platformType = IC
 # https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#multipleIDEVersions
 # When supporting multiple major versions, it is strongly recommended to build against

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pluginSinceBuild = 233
 # no upper bound for the version range -> see https://github.com/amitdev/PMD-Intellij/issues/213
 pluginUntilBuild =
 
-# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
+# Plugin Verifier integration -> https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-tasks.html#verifyPlugin
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 # Supporting five last major versions covers about 95% of the users
 # see https://intellij-support.jetbrains.com/hc/en-us/community/posts/18697727524754/comments/18765441074962
@@ -20,7 +20,10 @@ pluginUntilBuild =
 pluginVerifierIdeVersions = IC-2023.3, IC-2024.1, IC-2024.2, IC-2024.3, IC-2025.1
 
 platformType = IC
-platformVersion = 2024.1
+# https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#multipleIDEVersions
+# When supporting multiple major versions, it is strongly recommended to build against
+# the _lowest_ supported version to guarantee backwards-compatibility.
+platformVersion = 2023.3
 #platformVersion = 251-EAP-SNAPSHOT
 org.jetbrains.intellij.platform.downloadSources=true
 


### PR DESCRIPTION
This contains three changes:

- build against 2023.3 as recommended. 2023.3 (233) is the oldest supported version
  @jborgers you changed this in https://github.com/amitdev/PMD-Intellij/commit/ba4c03b654c1d14b4161f056b478845723b71f7f - I assume by accident?
- Disable caching for the verify job.
  This is a follow up on #221. Hopefully, the future releases run smoothly then.
- The property pluginVerifierIdeVersions was not used. The IDE versions to test against are determined automatically based on platformVersion (recommended()). With platformVersion=2023.3, verifyPlugin will execute verification against 2023.3.x, 2024.1.x, 2024.2.x, 2024.3.x, 2025.1.x and 2025.2.x. These are right now 6 versions, with each consuming at least 3GB we are already at 18GB... I guess, once 2025.2 is released, we should drop support for 2023.3.

Some background info on the caching problem: A similar problem is described in https://github.com/JetBrains/intellij-platform-plugin-template/issues/462 . We could do the suggestion in the [last comment](https://github.com/JetBrains/intellij-platform-plugin-template/issues/462#issuecomment-2745197887) and verify only against the earliest and latest release. But it would have the downside, that we might not see any incompatibilities. That's why I prefer to test the whole range.
The action gradle/action/setup-gradle does already much to reduce the cache sizes (see https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#select-which-branches-should-write-to-the-cache ), e.g. caches are only written from the main/master (default) branch and not from pull requests. But pull requests can still benefit from the cache from the default branch.

Note: Verification currently fails due to #238.
