### PR TITLE
add plugin icon to menu entries

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
   <actions>
     <!-- The Main menu item which includes predefined and custom rulesets -->
     <group id="PMDMenuGroup" text="Run PMD" popup="true"
-           class="com.intellij.plugins.bodhi.pmd.actions.PMDMenuGroup">
+           class="com.intellij.plugins.bodhi.pmd.actions.PMDMenuGroup" icon="/META-INF/pluginIcon.svg">
       <add-to-group group-id="ToolsMenu" anchor="last"/>
       <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
       <add-to-group group-id="ChangesViewPopupMenu" anchor="last"/>
@@ -35,6 +35,7 @@
                            implementation="com.intellij.plugins.bodhi.pmd.handlers.PMDCheckinHandlerFactory"/>
     <toolWindow id="PMD"
                 factoryClass="com.intellij.plugins.bodhi.pmd.PMDToolWindowFactory"
+                icon="/META-INF/pluginIcon.svg"
                 anchor="bottom"
                 canCloseContents="true"/>
     <externalAnnotator

--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="40"
-   height="40"
+   width="16"
+   height="16"
    viewBox="0 0 40 40"
    version="1.1"
    id="svg247"


### PR DESCRIPTION
This one is only to please my eyes :smile: 

I have notice that the icon in pmd toolbar is a default one from  intellij. Since there is already a svg in the sources lets use it to better identify the plugin in the different menu entries 

*screenshots what it render to :*

### Toolbar

![Capture d’écran du 2025-06-03 12-02-25](https://github.com/user-attachments/assets/e4b6bf38-1c64-4208-a897-34d6da76995d)

### right click on file or folder in project explorer

![Capture d’écran du 2025-06-03 12-02-42](https://github.com/user-attachments/assets/112f6e68-094a-4e43-aa55-b2c5ab01d413)

### top menu tools

![Capture d’écran du 2025-06-03 12-02-59](https://github.com/user-attachments/assets/fd88bdb4-6316-4685-bee6-64f89810847d)

