### PR TITLE
NPE when running PMD after importing new ruleset #230

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -169,11 +169,12 @@ public class PMDConfigurationForm {
     }
 
     private Object[][] toDescValueArray2d(Map<ConfigOption, String> optionToValue) {
-        String[][] result = new String[optionToValue.size()][2];
-        for (int i = 0; i < optionToValue.size(); i++) {
+        String[][] result = new String[ConfigOption.size()][2];
+        for (int i = 0; i < ConfigOption.size(); i++) {
             ConfigOption option = ConfigOption.values()[i];
             result[i][0] = option.getDescription();
-            result[i][1] = optionToValue.get(option);
+            String value = optionToValue.get(option);
+            result[i][1] = (value != null) ? value : option.getDefaultValue();
         }
         return result;
     }


### PR DESCRIPTION
When reading options data from file without Kotlin version, it would put in Kotlin version without the default value, resulting in a NPE later. Also Threads option was lost.
This is fixed with this PR.