### PR TITLE
Show popup menu on PMD rule nodes

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDResultPanel.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDResultPanel.java
@@ -376,9 +376,8 @@ public class PMDResultPanel extends JPanel implements HTMLReloadable {
             }
             if (treeNode instanceof PMDRuleNode pmdRuleNode) {
                 for (int i = 0; i < pmdRuleNode.getChildCount(); i++) {
-                    TreeNode childAt = pmdRuleNode.getChildAt(i);
-                    if (childAt instanceof  PMDViolationNode) {
-                        popupMenu.addViolation(((PMDViolationNode) childAt).getPmdViolation());
+                    if (pmdRuleNode.getChildAt(i) instanceof PMDViolationNode pmdViolationNode) {
+                        popupMenu.addViolation(pmdViolationNode.getPmdViolation());
                     }
                 }
             }


### PR DESCRIPTION
I love this plugin but sometimes I need to suppress PMD rules in bulk for easier adoption of the PMD plugin in legacy projects.

This popup menu allows suppressing multiple PMD violations of the same type. This simple change seems to work by adding all PMD violations to the list of violations within popupMenu.

<img width="1007" height="818" alt="image" src="https://github.com/user-attachments/assets/9345f59f-34fd-4232-8fdf-f8e0c50b35f7" />

Left click executes all edits and puts the nopmd comment for all violations under "MissingOverride".