### PR TITLE
Free more disk space by uninstalling large packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,6 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
-          large-packages: false
 
       # Check out the current repository
       - name: Fetch Sources


### PR DESCRIPTION
This removes more packages, allowing to run the "verifyPlugin" task to verify against 6 (!) IDE versions (241, 242, 243, 251, 252, 253).

Fixes #295

Once this is merged, I suggest to rerun the other open PRs (especially #298) and release a last version, that is compatible with 241. After that, we should update the minimum version (`pluginSinceBuild`) to at least 243 or newer. As, once 261 is released, we probably run into the disk space problem again.



