### PR TITLE
Breaking: Minimum required IntelliJ version is 2024.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
@@ -106,7 +106,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle
@@ -146,7 +146,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       # Setup Gradle
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: zulu
-          java-version: 17
+          java-version: 21
 
       # Check out current repository
       - name: Fetch Sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,7 @@
 
 ### Changed
 
-- Various improvements #266
-  - Fixed: Intermediate progress bars can't display fractional updates (when running PMD on multiple files)
-  - Fixed: IntelliJ crash on startup due to conflicting slf4j version
-  - Improve overall language detection
-  - Use/Display normal "Suppression Fix" if possible
-  - Prevent analysis of outdated file content from disk and use IntelliJ's internal PSIFile instead
-  - Do not classify unknown files as Java and ignore them
-  - Render rule descriptions as markdown
-  - Update to PMD version 7.21.0
+- 💥️ Breaking: Minimum required IntelliJ version is 2024.3+
 
 ## [2.0.9] - 2025-07-20
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ version = providers.gradleProperty("pluginVersion").get()
 
 // Set the JVM language level used to build the project.
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 // Configure project's dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 2.1.0
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 241
+pluginSinceBuild = 243
 # no upper bound for the version range -> see https://github.com/amitdev/PMD-Intellij/issues/213
 pluginUntilBuild =
 
@@ -16,7 +16,11 @@ platformType = IU
 # https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#multipleIDEVersions
 # When supporting multiple major versions, it is strongly recommended to build against
 # the _lowest_ supported version to guarantee backwards-compatibility.
-platformVersion = 2025.2
+# For convenience, we use a newer version here, probably the latest released version.
+# The plugin is still verified against older versions with the PluginVerifier
+# (https://plugins.jetbrains.com/docs/intellij/verifying-plugin-compatibility.html),
+# so it probably works with the older versions, but it is not guaranteed.
+platformVersion = 2025.3
 #platformVersion = 251-EAP-SNAPSHOT
 #platformVersion = 2025.1
 org.jetbrains.intellij.platform.downloadSources=true


### PR DESCRIPTION
Also use Java 21 (which is required since 242)