### PR TITLE
Bump pmd from 7.18.0 to 7.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update to PMD version 7.21.0
+
 ## [2.0.9] - 2025-07-20
 
 ### Changed

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 junit = "4.13.2"
-pmd = "7.18.0"
+pmd = "7.21.0"
 
 # plugins
 changelog = "2.4.0"


### PR DESCRIPTION
Bumps `pmd` from 7.18.0 to 7.21.0

* Release Notes 7.19.0: https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.19.0
* Release Notes 7.20.0: https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.20.0
* Release Notes 7.21.0: https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.21.0


This replaces and closes #298 