### PR TITLE
feat: support excluding root paths

### DIFF
--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationForm.java
@@ -55,6 +55,8 @@ public class PMDConfigurationForm {
     private JPanel mainPanel;
     private JCheckBox skipTestsCheckBox;
     private JList<String> inEditorAnnotationRuleSets;
+    private JList<String> excludeRootsJList;
+    private JPanel excludeRootsButtonPanel;
     private boolean isModified;
     private final Project project;
     private volatile Map<String, String> validKnownCustomRules;
@@ -71,6 +73,7 @@ public class PMDConfigurationForm {
         inEditorAnnotationRuleSets.setModel(new RuleSetListModel(new ArrayList<>()));
         inEditorAnnotationRuleSets.getSelectionModel().addListSelectionListener(new SelectionChangeListener());
         skipTestsCheckBox.addChangeListener(new CheckBoxChangeListener());
+        excludeRootsJList.setModel(new RuleSetListModel(new ArrayList<>()));
 
         // Timed retry-based initialization, to make sure intelliJ services are initialized before
         scheduleActionManagerInit(0);
@@ -121,6 +124,17 @@ public class PMDConfigurationForm {
         toolbar.getComponent().setVisible(true);
         buttonPanel.setLayout(new BorderLayout());
         buttonPanel.add(toolbar.getComponent(), BorderLayout.CENTER);
+
+        // Setup toolbar for exclude roots
+        DefaultActionGroup excludeRootsActionGroup = new DefaultActionGroup();
+        excludeRootsActionGroup.add(new AddExcludeRootAction("Add", "Add an exclude root path", PlatformIcons.ADD_ICON));
+        excludeRootsActionGroup.add(new EditExcludeRootAction("Edit", "Edit selected exclude root", PlatformIcons.EDIT));
+        excludeRootsActionGroup.add(new DeleteExcludeRootAction("Delete", "Remove selected exclude root", PlatformIcons.DELETE_ICON));
+        ActionToolbar excludeRootsToolbar = ActionManager.getInstance().createActionToolbar("exclude roots actions", excludeRootsActionGroup, true);
+        excludeRootsToolbar.setTargetComponent(excludeRootsToolbar.getComponent());
+        excludeRootsToolbar.getComponent().setVisible(true);
+        excludeRootsButtonPanel.setLayout(new BorderLayout());
+        excludeRootsButtonPanel.add(excludeRootsToolbar.getComponent(), BorderLayout.CENTER);
     }
 
     /**
@@ -164,6 +178,9 @@ public class PMDConfigurationForm {
         inEditorAnnotationRuleSets.setModel(inEditorAnnotationModel);
         inEditorAnnotationRuleSets.setSelectedIndices(inEditorAnnotationModel.getIndexes(dataProjComp.getInEditorAnnotationRuleSets()));
 
+        List<String> excludeRootsList = new ArrayList<>(dataProjComp.getExcludeRoots());
+        excludeRootsJList.setModel(new RuleSetListModel(excludeRootsList));
+
         isModified = false;
     }
 
@@ -187,6 +204,7 @@ public class PMDConfigurationForm {
         dataProjComp.setOptionToValue(toOptionToValue(optionsTable.getModel()));
         dataProjComp.skipTestSources(skipTestsCheckBox.isSelected());
         dataProjComp.setInEditorAnnotationRuleSets(inEditorAnnotationRuleSets.getSelectedValuesList());
+        dataProjComp.setExcludeRoots(((RuleSetListModel) excludeRootsJList.getModel()).getList());
 
         isModified = false;
     }
@@ -575,5 +593,138 @@ public class PMDConfigurationForm {
         public void valueChanged(ListSelectionEvent e) {
             isModified = true;
         }
+    }
+
+    private class AddExcludeRootAction extends AnEDTAction {
+        public AddExcludeRootAction(String text, String description, Icon icon) {
+            super(text, description, icon);
+        }
+
+        public void actionPerformed(@NotNull AnActionEvent e) {
+            String defaultValue = "";
+            modifyExcludeRoot(defaultValue);
+        }
+    }
+
+    private class EditExcludeRootAction extends AnEDTAction {
+        public EditExcludeRootAction(String text, String description, Icon icon) {
+            super(text, description, icon);
+        }
+
+        public void actionPerformed(@NotNull AnActionEvent e) {
+            String defaultValue = excludeRootsJList.getSelectedValue();
+            modifyExcludeRoot(defaultValue);
+        }
+
+        public void update(@NotNull AnActionEvent e) {
+            super.update(e);
+            e.getPresentation().setEnabled(!excludeRootsJList.getSelectionModel().isSelectionEmpty());
+        }
+    }
+
+    private class DeleteExcludeRootAction extends AnEDTAction {
+        public DeleteExcludeRootAction(String text, String description, Icon icon) {
+            super(text, description, icon);
+        }
+
+        public void actionPerformed(@NotNull AnActionEvent e) {
+            int index = excludeRootsJList.getSelectedIndex();
+            if (index != -1) {
+                ((RuleSetListModel) excludeRootsJList.getModel()).remove(index);
+                excludeRootsJList.setSelectedIndex(Math.min(index, excludeRootsJList.getModel().getSize() - 1));
+            }
+            excludeRootsJList.repaint();
+        }
+
+        public void update(@NotNull AnActionEvent e) {
+            super.update(e);
+            e.getPresentation().setEnabled(excludeRootsJList.getSelectedIndex() != -1);
+        }
+    }
+
+    private void modifyExcludeRoot(final String defaultValue) {
+
+        DialogBuilder db = new DialogBuilder(project);
+        db.addOkAction();
+        db.addCancelAction();
+        db.setTitle("Add/Edit Exclude Root Path");
+
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+
+        JLabel infoLabel = new JLabel("""
+                <html>Enter a relative path pattern (e.g., target/generated-sources) to exclude from all modules,<br>\
+                or an absolute path to exclude a specific directory.</html>""");
+        infoLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        panel.add(infoLabel);
+        panel.add(Box.createVerticalStrut(10));
+
+        JTextField pathTextField = new JTextField(defaultValue, 30);
+        pathTextField.setAlignmentX(Component.LEFT_ALIGNMENT);
+        pathTextField.setMaximumSize(new Dimension(Integer.MAX_VALUE, 26));
+        panel.add(pathTextField);
+
+        panel.add(Box.createVerticalStrut(10));
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
+        buttonPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
+        JButton browseButton = buildBrowseButton(panel, pathTextField);
+        buttonPanel.add(Box.createHorizontalGlue());
+        buttonPanel.add(browseButton);
+        buttonPanel.add(Box.createHorizontalGlue());
+        panel.add(buttonPanel);
+
+        db.setCenterPanel(panel);
+        db.show();
+
+        if (db.getDialogWrapper().getExitCode() == DialogWrapper.OK_EXIT_CODE) {
+            String excludePath = pathTextField.getText().trim();
+            if (!excludePath.isEmpty()) {
+                RuleSetListModel listModel = (RuleSetListModel) excludeRootsJList.getModel();
+                int selectedIndex = excludeRootsJList.getSelectedIndex();
+
+                if (defaultValue != null && !defaultValue.trim().isEmpty() && selectedIndex >= 0) {
+                    listModel.set(selectedIndex, excludePath);
+                } else {
+                    int index = listModel.getSize();
+                    listModel.add(index, excludePath);
+                    excludeRootsJList.setSelectedIndex(index);
+                }
+                excludeRootsJList.repaint();
+            }
+        }
+    }
+
+    @NotNull
+    private JButton buildBrowseButton(JPanel panel, JTextField pathTextField) {
+        JButton browseButton = new JButton("Browse...");
+        browseButton.addActionListener(e -> {
+            final VirtualFile toSelect = ProjectUtil.guessProjectDir(project);
+            final FileChooserDescriptor descriptor = new FileChooserDescriptor(false,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false);
+            descriptor.setTitle("Select Directory to Exclude");
+
+            final VirtualFile chosen = FileChooser.chooseFile(descriptor, panel, project, toSelect);
+            if (chosen != null) {
+                String basePath = project.getBasePath();
+                String chosenPath = chosen.getPath();
+
+                // Try to make it relative to project base path
+                if (basePath != null && chosenPath.startsWith(basePath)) {
+                    String relativePath = chosenPath.substring(basePath.length());
+                    if (relativePath.startsWith("/")) {
+                        relativePath = relativePath.substring(1);
+                    }
+                    pathTextField.setText(relativePath);
+                } else {
+                    pathTextField.setText(chosenPath);
+                }
+            }
+        });
+        return browseButton;
     }
 }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationPanel.form
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDConfigurationPanel.form
@@ -126,6 +126,56 @@
               </component>
             </children>
           </grid>
+          <grid id="excludeRootsTab" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <tabbedpane title="Exclude Roots"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="excludeRootsLabel" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Root paths to exclude from PMD analysis"/>
+                </properties>
+              </component>
+              <grid id="excludeRootsBtnContainer" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <xy id="excludeRootsBtnPanel" binding="excludeRootsButtonPanel" layout-manager="XYLayout" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none"/>
+                    <children/>
+                  </xy>
+                </children>
+              </grid>
+              <scrollpane id="excludeRootsScrollPane">
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="excludeRootsList" class="javax.swing.JList" binding="excludeRootsJList">
+                    <constraints/>
+                    <properties/>
+                  </component>
+                </children>
+              </scrollpane>
+            </children>
+          </grid>
         </children>
       </tabbedpane>
     </children>

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDInvoker.java
@@ -115,6 +115,9 @@ public class PMDInvoker {
             if (projectComponent.isSkipTestSources()) {
                 filter = and(filter, not(fileInTestSources(project)));
             }
+            if (!projectComponent.getExcludeRoots().isEmpty()) {
+                filter = and(filter, fileNotInExcludeRoots(projectComponent.getExcludeRoots()));
+            }
             filter = or(filter, isDirectory());
             for (VirtualFile selectedFile : selectedFiles) {
                 //Add all java files recursively

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PMDProjectComponent.java
@@ -50,6 +50,7 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
     private boolean skipTestSources;
     private boolean scanFilesBeforeCheckin;
     private Set<String> inEditorAnnotationRuleSets = new LinkedHashSet<>(); // avoid duplicates, maintain order
+    private Set<String> excludeRoots = new LinkedHashSet<>();
     private volatile List<AnAction> currentCustomActions = new ArrayList<>();
 
     /**
@@ -274,6 +275,9 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
         for (String item : inEditorAnnotationRuleSets) {
             persistentData.getInEditorAnnotationRules().add(item);
         }
+        for (String item : excludeRoots) {
+            persistentData.getExcludeRoots().add(item);
+        }
         return persistentData;
     }
 
@@ -303,6 +307,9 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
         inEditorAnnotationRuleSets.clear();
         inEditorAnnotationRuleSets.addAll(state.getInEditorAnnotationRules());
 
+        excludeRoots.clear();
+        excludeRoots.addAll(state.getExcludeRoots());
+
         this.skipTestSources = state.isSkipTestSources();
         this.scanFilesBeforeCheckin = state.isScanFilesBeforeCheckin();
 
@@ -326,5 +333,13 @@ public final class PMDProjectComponent implements PersistentStateComponent<Persi
 
     public boolean isScanFilesBeforeCheckin() {
         return scanFilesBeforeCheckin;
+    }
+
+    public Set<String> getExcludeRoots() {
+        return excludeRoots;
+    }
+
+    public void setExcludeRoots(List<String> excludeRoots) {
+        this.excludeRoots = new LinkedHashSet<>(excludeRoots);
     }
 }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/PersistentData.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/PersistentData.java
@@ -12,18 +12,21 @@ public class PersistentData {
     private boolean skipTestSources = DEFAULT_SKIP_TEST_SRC;
     private boolean scanFilesBeforeCheckin;
     private List<String> inEditorAnnotationRules;
+    private List<String> excludeRoots;
 
 
     public PersistentData() {
         this.customRuleSets = new ArrayList<>();
         this.inEditorAnnotationRules = new ArrayList<>();
         this.optionKeyToValue = new HashMap<>();
+        this.excludeRoots = new ArrayList<>();
     }
 
     public List<String> getCustomRuleSets() {
         return customRuleSets;
     }
 
+    @SuppressWarnings("unused")
     public void setCustomRuleSets(List<String> rules) {
         this.customRuleSets = rules;
     }
@@ -32,6 +35,7 @@ public class PersistentData {
         return optionKeyToValue;
     }
 
+    @SuppressWarnings("unused")
     public void setOptionKeyToValue(Map<String, String> opts) {
         optionKeyToValue = opts;
     }
@@ -44,6 +48,7 @@ public class PersistentData {
         return skipTestSources;
     }
 
+    @SuppressWarnings("unused")
     public void setInEditorAnnotationRules(List<String> inEditorAnnotationRules) {
         this.inEditorAnnotationRules = inEditorAnnotationRules;
     }
@@ -59,4 +64,12 @@ public class PersistentData {
         scanFilesBeforeCheckin = scan;
     }
 
+    public List<String> getExcludeRoots() {
+        return excludeRoots;
+    }
+
+    @SuppressWarnings("unused")
+    public void setExcludeRoots(List<String> excludeRoots) {
+        this.excludeRoots = excludeRoots;
+    }
 }

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDExternalLanguageAnnotator.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/annotator/PMDExternalLanguageAnnotator.java
@@ -18,7 +18,6 @@ import com.intellij.plugins.bodhi.pmd.annotator.langversion.ManagedLanguageVersi
 import com.intellij.plugins.bodhi.pmd.core.PMDResultCollector;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
-import com.intellij.webSymbols.utils.HtmlMarkdownUtils;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.rule.Rule;

--- a/src/main/java/com/intellij/plugins/bodhi/pmd/filter/VirtualFileFilters.java
+++ b/src/main/java/com/intellij/plugins/bodhi/pmd/filter/VirtualFileFilters.java
@@ -6,6 +6,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileFilter;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Set;
+
 public class VirtualFileFilters
 {
     public static VirtualFileFilter and(VirtualFileFilter... filters)
@@ -41,6 +43,11 @@ public class VirtualFileFilters
     public static VirtualFileFilter fileInSources(Project project)
     {
         return new FileInSourcesFilter(project);
+    }
+
+    public static VirtualFileFilter fileNotInExcludeRoots(Set<String> excludeRoots)
+    {
+        return new FileNotInExcludeRootsFilter(excludeRoots);
     }
 
     static class AndFilter implements VirtualFileFilter
@@ -154,6 +161,72 @@ public class VirtualFileFilters
         public boolean accept(@NotNull VirtualFile file)
         {
             return !filter.accept(file);
+        }
+    }
+
+    static class FileNotInExcludeRootsFilter implements VirtualFileFilter
+    {
+        private final Set<String> excludeRoots;
+
+        FileNotInExcludeRootsFilter(Set<String> excludeRoots)
+        {
+            this.excludeRoots = excludeRoots;
+        }
+
+        public boolean accept(@NotNull VirtualFile file)
+        {
+            if (excludeRoots.isEmpty()) {
+                return true;
+            }
+
+
+            String filePath = file.getPath();
+            for (String excludeRoot : excludeRoots) {
+                String normalizedExcludeRoot = excludeRoot.trim();
+                if (normalizedExcludeRoot.isEmpty()) {
+                    continue;
+                }
+
+                if (isAbsolutePath(normalizedExcludeRoot)) {
+                    if (filePath.startsWith(normalizedExcludeRoot)) {
+                        return false;
+                    }
+                } else {
+                    if (matchesRelativePattern(filePath, normalizedExcludeRoot)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Checks if the file path matches a relative exclude pattern.
+         * The pattern is normalized to /pattern/ and we check if the file path contains it.
+         *  <br/>
+         * For example, pattern "target/generated-sources" becomes "/target/generated-sources/"
+         * and will match any path containing that segment:
+         * - /project/target/generated-sources/Foo.java
+         * - /project/module1/target/generated-sources/Bar.java
+         */
+        private boolean matchesRelativePattern(String filePath, String pattern) {
+            return  normalizePath(filePath).contains(normalizePath(pattern));
+        }
+
+        private static String normalizePath(String path) {
+            String normalizedPath = path;
+            if (!normalizedPath.startsWith("/")) {
+                normalizedPath = "/" + normalizedPath;
+            }
+            if (!normalizedPath.endsWith("/")) {
+                normalizedPath = normalizedPath + "/";
+            }
+            return normalizedPath;
+        }
+
+        private static boolean isAbsolutePath(String path) {
+            // Unix absolute path or Windows absolute path (e.g., C:\)
+            return path.startsWith("/") || (path.length() > 2 && path.charAt(1) == ':');
         }
     }
 }


### PR DESCRIPTION
fix https://github.com/amitdev/PMD-Intellij/issues/62

Here is a proposal to support excluding roots paths. This feature rely on path methods that should be system independent. I tested on a linux setup so there theoretically it should have no issues on macos but I don't have a windows setup on my hands so I can't ensure that everything works fine on it (I'll try to find one). 



It add a new tab `Exclude Roots` on pmd settings : 

<img width="400"  src="https://github.com/user-attachments/assets/1aa5ac10-afe9-409f-b106-cd039f0bf41e" />



when adding a new path, it open a popup that allow to either write manually the path  or through a file chooser using `browse` button. 
When using file chooser, we will try to make the selected path relative the base path of the project to ease portability of the configuration. 


<img width="400"  src="https://github.com/user-attachments/assets/e35ef44a-e15c-4eef-b28f-767764baba03" />
